### PR TITLE
UIER-22 Basket: Added ability to add basket items to existing agreements

### DIFF
--- a/src/components/Agreements/AgreementForm/AgreementForm.js
+++ b/src/components/Agreements/AgreementForm/AgreementForm.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
 import {
   AccordionSet,
   Col,
@@ -13,10 +12,6 @@ import {
 } from './Sections';
 
 class AgreementForm extends React.Component {
-  static propTypes = {
-    intl: intlShape,
-  };
-
   state = {
     sections: {
       agreementFormInfo: true,
@@ -26,8 +21,10 @@ class AgreementForm extends React.Component {
 
   getSectionProps() {
     return {
+      agreementLines: this.props.agreementLines,
       onToggle: this.handleSectionToggle,
-      ...this.props,
+      parentResources: this.props.parentResources,
+      stripes: this.props.stripes,
     };
   }
 
@@ -61,4 +58,4 @@ class AgreementForm extends React.Component {
   }
 }
 
-export default injectIntl(AgreementForm);
+export default AgreementForm;

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
@@ -23,6 +23,7 @@ class AgreementFormEresources extends React.Component {
     intl: intlShape,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
+    parentResources: PropTypes.object,
     stripes: PropTypes.object,
   };
 
@@ -32,6 +33,9 @@ class AgreementFormEresources extends React.Component {
 
   getLineResource(line) {
     if (line.resource) return line.resource;
+
+    const basketLine = this.props.parentResources.basket.find(l => l.id === line.id);
+    if (basketLine) return basketLine;
 
     const foundLine = this.props.agreementLines.find(l => l.id === line.id);
     if (foundLine) return foundLine.resource;

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
@@ -32,13 +32,19 @@ class AgreementFormEresources extends React.Component {
   }
 
   getLineResource(line) {
+    const { parentResources, agreementLines } = this.props;
+
     if (line.resource) return line.resource;
 
-    const basketLine = this.props.parentResources.basket.find(l => l.id === line.id);
-    if (basketLine) return basketLine;
+    if (parentResources && parentResources.basket) {
+      const basketLine = parentResources.basket.find(l => l.id === line.id);
+      if (basketLine) return basketLine;
+    }
 
-    const foundLine = this.props.agreementLines.find(l => l.id === line.id);
-    if (foundLine) return foundLine.resource;
+    if (agreementLines) {
+      const foundLine = agreementLines.find(l => l.id === line.id);
+      if (foundLine) return foundLine.resource;
+    }
 
     return undefined;
   }

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormInfo.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import { Field } from 'redux-form';
 
@@ -17,7 +17,6 @@ import {
 class AgreementFormInfo extends React.Component {
   static propTypes = {
     id: PropTypes.string,
-    intl: intlShape,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
     parentResources: PropTypes.shape({
@@ -51,12 +50,10 @@ class AgreementFormInfo extends React.Component {
   }
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-erm.agreements.agreementInfo' })}
+        label={<FormattedMessage id="ui-erm.agreements.agreementInfo" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -65,7 +62,7 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="name"
               name="name"
-              label={`${intl.formatMessage({ id: 'ui-erm.agreements.name' })} *`}
+              label={<FormattedMessage id="ui-erm.agreements.name">{name => `${name} *`}</FormattedMessage>}
               component={TextField}
             />
           </Col>
@@ -75,7 +72,7 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="description"
               name="description"
-              label={intl.formatMessage({ id: 'ui-erm.agreements.agreementDescription' })}
+              label={<FormattedMessage id="ui-erm.agreements.agreementDescription" />}
               component={TextArea}
             />
           </Col>
@@ -85,27 +82,30 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="startDate"
               name="startDate"
-              label={`${intl.formatMessage({ id: 'ui-erm.agreements.startDate' })} *`}
+              label={<FormattedMessage id="ui-erm.agreements.startDate">{startDate => `${startDate} *`}</FormattedMessage>}
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
+              backendDateStandard="YYYY-MM-DD"
             />
           </Col>
           <Col xs={12} md={4}>
             <Field
               id="endDate"
               name="endDate"
-              label={intl.formatMessage({ id: 'ui-erm.agreements.endDate' })}
+              label={<FormattedMessage id="ui-erm.agreements.endDate" />}
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
+              backendDateStandard="YYYY-MM-DD"
             />
           </Col>
           <Col xs={12} md={4}>
             <Field
               id="cancellationDeadline"
               name="cancellationDeadline"
-              label={intl.formatMessage({ id: 'ui-erm.agreements.cancellationDeadline' })}
+              label={<FormattedMessage id="ui-erm.agreements.cancellationDeadline" />}
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
+              backendDateStandard="YYYY-MM-DD"
             />
           </Col>
         </Row>
@@ -114,7 +114,7 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="agreementStatus"
               name="agreementStatus"
-              label={`${intl.formatMessage({ id: 'ui-erm.agreements.agreementStatus' })} *`}
+              label={<FormattedMessage id="ui-erm.agreements.agreementStatus">{agreementStatus => `${agreementStatus} *`}</FormattedMessage>}
               component={Select}
               dataOptions={this.getAgreementStatusValues()}
             />
@@ -123,7 +123,7 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="renewalPriority"
               name="renewalPriority"
-              label={intl.formatMessage({ id: 'ui-erm.agreements.renewalPriority' })}
+              label={<FormattedMessage id="ui-erm.agreements.renewalPriority" />}
               component={Select}
               dataOptions={this.getRenewalPriorityValues()}
             />
@@ -132,7 +132,7 @@ class AgreementFormInfo extends React.Component {
             <Field
               id="isPerpetual"
               name="isPerpetual"
-              label={intl.formatMessage({ id: 'ui-erm.agreements.isPerpetual' })}
+              label={<FormattedMessage id="ui-erm.agreements.isPerpetual" />}
               component={Select}
               dataOptions={this.getIsPerpetualValues()}
             />
@@ -143,4 +143,4 @@ class AgreementFormInfo extends React.Component {
   }
 }
 
-export default injectIntl(AgreementFormInfo);
+export default AgreementFormInfo;

--- a/src/components/Agreements/EditAgreement/EditAgreement.js
+++ b/src/components/Agreements/EditAgreement/EditAgreement.js
@@ -29,9 +29,6 @@ class EditAgreement extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
-    location: PropTypes.shape({
-      search: PropTypes.string,
-    }),
     onSave: PropTypes.func,
     onCancel: PropTypes.func,
     onRemove: PropTypes.func,

--- a/src/components/Agreements/EditAgreement/EditAgreement.js
+++ b/src/components/Agreements/EditAgreement/EditAgreement.js
@@ -6,6 +6,8 @@ import { Button, IconButton, Pane, PaneMenu } from '@folio/stripes/components';
 
 import AgreementForm from '../AgreementForm';
 
+const ADD_FROM_BASKET_PARAM = 'addFromBasket';
+
 const validate = (values) => {
   const required = ['name', 'startDate', 'agreementStatus'];
   const errors = {};
@@ -28,6 +30,9 @@ class EditAgreement extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
+    location: PropTypes.shape({
+      search: PropTypes.string,
+    }),
     onSave: PropTypes.func,
     onCancel: PropTypes.func,
     onRemove: PropTypes.func,
@@ -35,6 +40,28 @@ class EditAgreement extends React.Component {
     submitting: PropTypes.bool,
     parentResources: PropTypes.object,
     parentMutator: PropTypes.object
+  }
+
+  componentDidMount() {
+    const { initialValues = {}, location: { search }, parentResources } = this.props;
+
+    if (search.includes(ADD_FROM_BASKET_PARAM)) {
+      const query = search.split('&').find(q => q.includes(ADD_FROM_BASKET_PARAM));
+      const indices = query.split('=')[1].split('%2C');
+
+      if (indices.length) {
+        const itemsToAdd = indices
+          .map(i => ({ resource: parentResources.basket[i] }))
+          .filter(i => i);
+
+        const items = [
+          ...(initialValues.items || []),
+          ...itemsToAdd,
+        ];
+
+        this.props.change('items', items);
+      }
+    }
   }
 
   renderFirstMenu() {

--- a/src/components/Agreements/EditAgreement/EditAgreement.js
+++ b/src/components/Agreements/EditAgreement/EditAgreement.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { get, isEqual } from 'lodash';
 import stripesForm from '@folio/stripes/form';
 import { Button, IconButton, Pane, PaneMenu } from '@folio/stripes/components';
 
@@ -40,8 +41,47 @@ class EditAgreement extends React.Component {
     parentMutator: PropTypes.object
   }
 
+  static defaultProps = {
+    initialValues: {},
+  }
+
+  state = {
+    addedResourcesFromBasket: [],
+  }
+
   componentDidMount() {
-    const { initialValues = {}, parentMutator, parentResources: { query, basket } } = this.props;
+    this.updateAddedResourcesFromBasket();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    // If we've stayed mounted but now have to handle a newly-added `addFromBasket` query param,
+    // update the added resources from the basket.
+    if (get(this.props.parentResources, ['query', 'addFromBasket']) && !get(prevProps.parentResources, ['query', 'addFromBasket'])) {
+      this.updateAddedResourcesFromBasket();
+    }
+
+    // The value of the `items` field can be fed by the basket or if we're _editing_, the
+    // previously-persisted values. We need to merge these two arrays when we get that data changes.s
+    if (
+      !isEqual(this.props.initialValues, prevProps.initialValues) ||
+      !isEqual(this.state.addedResourcesFromBasket, prevState.addedResourcesFromBasket)
+    ) {
+      this.props.change(
+        'items',
+        [
+          ...get(this.props, ['initialValues', 'items'], []),
+          ...this.state.addedResourcesFromBasket,
+        ]
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    this.props.parentMutator.query.replace({ addFromBasket: null });
+  }
+
+  updateAddedResourcesFromBasket() {
+    const { parentResources: { query, basket } } = this.props;
 
     if (query.addFromBasket) {
       // Get the indices of the basket items we're supposed to add
@@ -49,21 +89,12 @@ class EditAgreement extends React.Component {
 
       if (indices.length) {
         // Construct the _entitlement_ from those resources in the basket.
-        const itemsToAdd = indices
+        const addedResourcesFromBasket = indices
           .map(i => ({ resource: basket[parseInt(i, 10)] }))
           .filter(i => i.resource);
 
-        const items = [
-          ...(initialValues.items || []),
-          ...itemsToAdd,
-        ];
-
-        // Remove the query param since we've handled it and don't want it hanging
-        // around the next time the user creates/edits an agreement.
-        parentMutator.query.replace({ addFromBasket: null });
-
-        // Use redux-form to set the `items` part of the form using the new array.
-        this.props.change('items', items);
+        // Save off the resource objects we're adding from the basket
+        this.setState({ addedResourcesFromBasket });
       }
     }
   }
@@ -71,26 +102,30 @@ class EditAgreement extends React.Component {
   renderFirstMenu() {
     return (
       <PaneMenu>
-        <IconButton
-          icon="closeX"
-          onClick={this.props.onCancel}
-          aria-label={this.props.stripes.intl.formatMessage({ id: 'ui-erm.agreements.closeNewAgreement' })}
-        />
+        <FormattedMessage id="ui-erm.agreements.closeNewAgreement">
+          {ariaLabel => (
+            <IconButton
+              icon="closeX"
+              onClick={this.props.onCancel}
+              aria-label={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
 
   renderLastMenu() {
-    const { initialValues, stripes: { intl } } = this.props;
+    const { initialValues } = this.props;
 
     let id;
-    let label;
-    if (initialValues && initialValues.id) {
+    let labelId;
+    if (initialValues.id) {
       id = 'clickable-updateagreement';
-      label = intl.formatMessage({ id: 'ui-erm.agreements.updateAgreement' });
+      labelId = 'ui-erm.agreements.updateAgreement';
     } else {
       id = 'clickable-createagreement';
-      label = intl.formatMessage({ id: 'ui-erm.agreements.createAgreement' });
+      labelId = 'ui-erm.agreements.createAgreement';
     }
 
     return (
@@ -98,23 +133,20 @@ class EditAgreement extends React.Component {
         <Button
           id={id}
           type="submit"
-          title={label}
-          aria-label={label}
           disabled={this.props.pristine || this.props.submitting}
           onClick={this.props.handleSubmit}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0
         >
-          {label}
+          <FormattedMessage id={labelId} />
         </Button>
       </PaneMenu>
     );
   }
 
   render() {
-    const { initialValues, stripes: { intl } } = this.props;
-    const paneTitle = initialValues && initialValues.id ?
-      initialValues.name : intl.formatMessage({ id: 'ui-erm.agreements.createAgreement' });
+    const { initialValues } = this.props;
+    const paneTitle = initialValues.id ? initialValues.name : <FormattedMessage id="ui-erm.agreements.createAgreement" />;
 
     return (
       <form id="form-agreement">
@@ -137,4 +169,5 @@ export default stripesForm({
   onSubmit: handleSubmit,
   navigationCheck: true,
   enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
 })(EditAgreement);

--- a/src/components/Basket/Basket.js
+++ b/src/components/Basket/Basket.js
@@ -169,7 +169,7 @@ class Basket extends React.Component {
                 <div>
                   <Headline bold>{agreement.name}&nbsp;&#40;{agreement.agreementStatus.label}&#41;</Headline>{/* eslint-disable-line */}
                   <div>
-                    <FormattedMessage id="ui-erm.agreements.startDate" />: <FormattedDate value={agreement.startDate} /> {/* eslint-disable-line */}
+                    <strong><FormattedMessage id="ui-erm.agreements.startDate" />: </strong><FormattedDate value={agreement.startDate} /> {/* eslint-disable-line */}
                   </div>
                   {agreement.vendor && (
                     <div>

--- a/src/components/Basket/Basket.js
+++ b/src/components/Basket/Basket.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
 
 import {
+  Button,
   IconButton,
   Layer,
   Pane,
@@ -10,6 +12,8 @@ import {
 } from '@folio/stripes/components';
 
 import BasketList from './BasketList';
+
+const ADD_FROM_BASKET_PARAM = 'addFromBasket';
 
 class Basket extends React.Component {
   static manifest = Object.freeze({
@@ -31,14 +35,13 @@ class Basket extends React.Component {
       basket: PropTypes.array,
       query: PropTypes.object,
     }),
-    stripes: PropTypes.object,
   }
 
-  closeBasket = () => {
+  handleCloseBasket = () => {
     this.props.mutator.query.update({ basket: undefined });
   }
 
-  removeItem = (item) => {
+  handleRemoveItem = (item) => {
     const { mutator, resources } = this.props;
 
     const basket = resources.basket || [];
@@ -50,43 +53,57 @@ class Basket extends React.Component {
   renderFirstMenu = () => {
     return (
       <PaneMenu>
-        <IconButton
-          icon="closeX"
-          onClick={this.closeBasket}
-          aria-label={this.props.stripes.intl.formatMessage({ id: 'ui-erm.basket.close' })}
-        />
+        <FormattedMessage id="ui-erm.basket.close">
+          {ariaLabel => (
+            <IconButton
+              icon="closeX"
+              onClick={this.handleCloseBasket}
+              aria-label={ariaLabel}
+            />
+          )}
+        </FormattedMessage>
       </PaneMenu>
     );
   }
 
   render() {
-    const { container, resources, stripes: { intl } } = this.props;
+    const { container, resources } = this.props;
 
     const basket = resources.basket || [];
     const query = resources.query;
 
     return (
-      <Layer
-        container={container}
-        contentLabel={intl.formatMessage({ id: 'ui-erm.basket.layerLabel' })}
-        isOpen={!!query.basket}
-      >
-        <Paneset>
-          <Pane
-            defaultWidth="100%"
-            firstMenu={this.renderFirstMenu()}
-            paneTitle={intl.formatMessage({ id: 'ui-erm.basket.name' })}
-            paneSub={intl.formatMessage({ id: 'ui-erm.basket.recordCount' }, { count: basket.length })}
-
+      <FormattedMessage id="ui-erm.basket.layerLabel">
+        {layerContentLabel => (
+          <Layer
+            container={container}
+            contentLabel={layerContentLabel}
+            isOpen={!!query.basket}
           >
-            <BasketList
-              basket={basket}
-              removeItem={this.removeItem}
-            />
-          </Pane>
-        </Paneset>
-      </Layer>
-    )
+            <Paneset>
+              <Pane
+                defaultWidth="100%"
+                firstMenu={this.renderFirstMenu()}
+                paneTitle={<FormattedMessage id="ui-erm.basket.name" />}
+                paneSub={<FormattedMessage id="ui-erm.basket.recordCount" values={{ count: basket.length }} />}
+
+              >
+                <BasketList
+                  basket={basket}
+                  removeItem={this.handleRemoveItem}
+                />
+                <Button
+                  buttonStyle="primary"
+                  to={`/erm/agreements?layer=create&${ADD_FROM_BASKET_PARAM}=${basket.map((a, i) => i).join(',')}`}
+                >
+                  <FormattedMessage id="ui-erm.basket.createAgreement" />
+                </Button>
+              </Pane>
+            </Paneset>
+          </Layer>
+        )}
+      </FormattedMessage>
+    );
   }
 }
 

--- a/src/components/Basket/BasketList.js
+++ b/src/components/Basket/BasketList.js
@@ -18,11 +18,14 @@ class BasketList extends React.Component {
   static propTypes = {
     basket: PropTypes.arrayOf(PropTypes.object),
     intl: intlShape,
+    onToggleAll: PropTypes.func,
+    onToggleItem: PropTypes.func,
     removeItem: PropTypes.func,
+    selectedItems: PropTypes.object,
   }
 
   render() {
-    const { basket, intl, removeItem } = this.props;
+    const { basket, intl, removeItem, selectedItems } = this.props;
 
     return (
       <Row>
@@ -32,6 +35,7 @@ class BasketList extends React.Component {
             interactive={false}
             maxHeight={400}
             visibleColumns={[
+              'selected',
               'name',
               'type',
               'package',
@@ -42,6 +46,13 @@ class BasketList extends React.Component {
               'remove'
             ]}
             formatter={{
+              selected: resource => (
+                <Checkbox
+                  name={`selected-${resource.id}`}
+                  checked={!!(selectedItems[resource.id])}
+                  onChange={() => this.props.onToggleItem(resource)}
+                />
+              ),
               name: resource => <Link to={`/erm/eresources/view/${resource.id}`}>{resource.name}</Link>,
               type: resource => renderResourceType(resource),
               package: resource => {
@@ -66,6 +77,13 @@ class BasketList extends React.Component {
               )
             }}
             columnMapping={{
+              selected: (
+                <Checkbox
+                  name="selected-all"
+                  checked={Object.values(selectedItems).includes(false) !== true}
+                  onChange={this.props.onToggleAll}
+                />
+              ),
               name: intl.formatMessage({ id: 'ui-erm.eresources.name' }),
               type: intl.formatMessage({ id: 'ui-erm.eresources.type' }),
               package: intl.formatMessage({ id: 'ui-erm.eresources.parentPackage' }),

--- a/src/components/Basket/BasketList.js
+++ b/src/components/Basket/BasketList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import Link from 'react-router-dom/Link';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Checkbox,
@@ -17,7 +17,6 @@ import { renderResourceType } from '../../util/resourceType';
 class BasketList extends React.Component {
   static propTypes = {
     basket: PropTypes.arrayOf(PropTypes.object),
-    intl: intlShape,
     onToggleAll: PropTypes.func,
     onToggleItem: PropTypes.func,
     removeItem: PropTypes.func,
@@ -25,7 +24,7 @@ class BasketList extends React.Component {
   }
 
   render() {
-    const { basket, intl, removeItem, selectedItems } = this.props;
+    const { basket, removeItem, selectedItems } = this.props;
 
     return (
       <Row>
@@ -69,11 +68,15 @@ class BasketList extends React.Component {
               coverageStart: () => 'TBD',
               coverageEnd: () => 'TBD',
               remove: resource => (
-                <IconButton
-                  aria-label={intl.formatMessage({ id: 'ui-erm.basket.removeItem' })}
-                  icon="trashBin"
-                  onClick={() => removeItem(resource)}
-                />
+                <FormattedMessage id="ui-erm.basket.removeItem">
+                  {ariaLabel => (
+                    <IconButton
+                      aria-label={ariaLabel}
+                      icon="trashBin"
+                      onClick={() => removeItem(resource)}
+                    />
+                  )}
+                </FormattedMessage>
               )
             }}
             columnMapping={{
@@ -84,16 +87,17 @@ class BasketList extends React.Component {
                   onChange={this.props.onToggleAll}
                 />
               ),
-              name: intl.formatMessage({ id: 'ui-erm.eresources.name' }),
-              type: intl.formatMessage({ id: 'ui-erm.eresources.type' }),
-              package: intl.formatMessage({ id: 'ui-erm.eresources.parentPackage' }),
-              publisher: intl.formatMessage({ id: 'ui-erm.eresources.publisher' }),
-              platform: intl.formatMessage({ id: 'ui-erm.eresources.platform' }),
-              coverageStart: intl.formatMessage({ id: 'ui-erm.eresources.coverageStart' }),
-              coverageEnd: intl.formatMessage({ id: 'ui-erm.eresources.coverageEnd' }),
-              remove: intl.formatMessage({ id: 'ui-erm.remove' }),
+              name: <FormattedMessage id="ui-erm.eresources.name" />,
+              type: <FormattedMessage id="ui-erm.eresources.type" />,
+              package: <FormattedMessage id="ui-erm.eresources.parentPackage" />,
+              publisher: <FormattedMessage id="ui-erm.eresources.publisher" />,
+              platform: <FormattedMessage id="ui-erm.eresources.platform" />,
+              coverageStart: <FormattedMessage id="ui-erm.eresources.coverageStart" />,
+              coverageEnd: <FormattedMessage id="ui-erm.eresources.coverageEnd" />,
+              remove: <FormattedMessage id="ui-erm.remove" />,
             }}
             columnWidths={{
+              selected: 40,
               name: '30%',
             }}
           />
@@ -103,4 +107,4 @@ class BasketList extends React.Component {
   }
 }
 
-export default injectIntl(BasketList);
+export default BasketList;

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -41,6 +41,7 @@ class Tabs extends React.Component {
     this.setState({ tab: id });
     this.props.parentMutator.query.replace({
       _path: `/erm/${id}`,
+      addFromBasket: null,
       layer: null,
     });
     this.props.parentMutator.resultCount.replace(1);

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -66,10 +66,11 @@ class Agreements extends React.Component {
       type: 'okapi',
       path: 'erm/refdataValues/SubscriptionAgreement/contentReviewNeeded',
     },
+    agreementFiltersInitialized: { initialValue: false },
+    basket: { initialValue: [] },
     query: {},
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     selectedAgreementId: { initialValue: '' },
-    agreementFiltersInitialized: { initialValue: false },
   });
 
   static propTypes = {

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -66,6 +66,8 @@
   "basket.removeItem": "Remove item from basket",
   "basket.parentPackage": "Parent package",
   "basket.createAgreement": "Create new agreement",
+  "basket.addToExistingAgreement": "Add to existing agreement",
+  "basket.addToSelectedAgreement": "Add to selected agreement",
 
   "basketSelector.selectLabel": "Select from basket",
   "basketSelector.selectPlaceholder": "Select e-resource or package",

--- a/translations/ui-erm/en.json
+++ b/translations/ui-erm/en.json
@@ -65,6 +65,7 @@
   "basket.layerLabel": "View E-resources in the ERM basket",
   "basket.removeItem": "Remove item from basket",
   "basket.parentPackage": "Parent package",
+  "basket.createAgreement": "Create new agreement",
 
   "basketSelector.selectLabel": "Select from basket",
   "basketSelector.selectPlaceholder": "Select e-resource or package",


### PR DESCRIPTION
The Basket is now fully(?) in place and we can add resources to agreements from:

- the Edit Agreement page, where we select resources from the basket. (Added previously)
- the Basket, where we select resource and create new agreements based on them. (Added previously)
- the Basket, where we select resources and add them to existing agreements.

Had a decent amount of wrenching to do to get redux-form to do what I wanted (what else is new?) but that should be it.

Next up:
- handling all the busywork for the renamed repo.
- listing all individual titles, broken out of packages, covered by an agreement.