### PR TITLE
Tabs: Keep separate set of filters/sort for agreements and eresources

### DIFF
--- a/src/ERM.js
+++ b/src/ERM.js
@@ -18,6 +18,18 @@ const INITIAL_RESULT_COUNT = 100;
 export default class ERM extends React.Component {
   static manifest = Object.freeze({
     query: {},
+    queryAgreements: {
+      initialValue: {
+        filters: 'agreementStatus.Requested,agreementStatus.In Negotiation,agreementStatus.Draft,agreementStatus.Active',
+        sort: 'Name',
+      }
+    },
+    queryEresources: {
+      initialValue: {
+        filters: null,
+        sort: 'Name',
+      }
+    },
     resultCount: { initialValue: INITIAL_RESULT_COUNT }
   });
 

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -13,6 +13,7 @@ class Tabs extends React.Component {
       PropTypes.number,
     ]),
     parentMutator: PropTypes.object,
+    parentResources: PropTypes.object,
   };
 
   state = {
@@ -31,6 +32,30 @@ class Tabs extends React.Component {
     this.setTab();
   }
 
+  getPersistedQuery = (id) => {
+    const { parentResources } = this.props;
+    let prev = { filters: null, sort: null };
+    if (id === 'agreements') prev = parentResources.queryAgreements;
+    else if (id === 'eresources') prev = parentResources.queryEresources;
+
+    return prev;
+  }
+
+  persistSortAndFilters = () => {
+    const { parentMutator, parentResources } = this.props;
+    const { tab } = this.state;
+    let mutator;
+
+    if (tab === 'agreements') mutator = parentMutator.queryAgreements;
+    else if (tab === 'eresources') mutator = parentMutator.queryEresources;
+    else return;
+
+    mutator.replace({
+      filters: parentResources.query.filters,
+      sort: parentResources.query.sort,
+    });
+  }
+
   setTab = () => {
     const { tab } = this.props;
     if (!tab) return;
@@ -38,12 +63,17 @@ class Tabs extends React.Component {
   }
 
   handleActivate = ({ id }) => {
+    this.persistSortAndFilters();
+
     this.setState({ tab: id });
+
     this.props.parentMutator.query.replace({
       _path: `/erm/${id}`,
       addFromBasket: null,
       layer: null,
+      ...this.getPersistedQuery(id),
     });
+
     this.props.parentMutator.resultCount.replace(1);
   }
 


### PR DESCRIPTION
Previously, switching between the Agreements and E-resources tabs would keep the same filters/sort applied. This didn't really feel right to me so I've changed it to save off the current filters/sort whenever you're leaving to go to another tab, and then pull the persisted filters/sort off when you go _back_ to that tab.

Also turned on a default filter of non-closed agreements per UIER-4.