### PR TITLE
Replace formatMessage() with <FormattedMessage>

### DIFF
--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormEresources.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { get } from 'lodash';
 import { FieldArray } from 'redux-form';
 import Link from 'react-router-dom/Link';
@@ -91,7 +91,7 @@ class AgreementFormEresources extends React.Component {
         <MultiColumnList
           contentData={renderedLines}
           interactive={false}
-          isEmptyMessage={intl.formatMessage({ id: 'ui-agreements.agreementLines.noLines' })}
+          isEmptyMessage={<FormattedMessage id="ui-agreements.agreementLines.noLines" />}
           maxHeight={400}
           visibleColumns={[
             'name',
@@ -121,11 +121,15 @@ class AgreementFormEresources extends React.Component {
             },
             remove: ({ rowIndex, id }) => {
               return (
-                <IconButton
-                  aria-label={intl.formatMessage({ id: 'ui-agreements.agreementLines.removeItem' })}
-                  icon="trashBin"
-                  onClick={() => this.onRemoveAgreementLine(fields, rowIndex, id)}
-                />
+                <FormattedMessage id="ui-agreements.agreementLines.removeItem">
+                  {ariaLabel => (
+                    <IconButton
+                      aria-label={ariaLabel}
+                      icon="trashBin"
+                      onClick={() => this.onRemoveAgreementLine(fields, rowIndex, id)}
+                    />
+                  )}
+                </FormattedMessage>
               );
             },
           }}
@@ -144,7 +148,7 @@ class AgreementFormEresources extends React.Component {
           }}
         />
         <BasketSelector
-          addButtonLabel={intl.formatMessage({ id: 'ui-agreements.agreementLines.createLine' })}
+          addButtonLabel={<FormattedMessage id="ui-agreements.agreementLines.createLine" />}
           onAdd={entitlement => this.onAddAgreementLine(fields, entitlement)}
           stripes={stripes}
         />
@@ -153,12 +157,10 @@ class AgreementFormEresources extends React.Component {
   }
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.eresourceAgreementLines' })}
+        label={<FormattedMessage id="ui-agreements.agreements.eresourceAgreementLines" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >

--- a/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import {
   Accordion,
@@ -12,13 +12,12 @@ import {
 
 import css from './AgreementInfo.css';
 
-class AgreementInfo extends React.Component {
+export default class AgreementInfo extends React.Component {
   static propTypes = {
     agreement: PropTypes.object,
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   state = {
@@ -40,18 +39,18 @@ class AgreementInfo extends React.Component {
   }
 
   render() {
-    const { agreement, intl } = this.props;
+    const { agreement } = this.props;
 
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.agreementInfo' })}
+        label={<FormattedMessage id="ui-agreements.agreements.agreementInfo" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
         <Row>
           <Col xs={12}>
-            <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.name' })}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.agreements.name" />}>
               <div data-test-agreement-name>
                 {agreement.name}
               </div>
@@ -60,7 +59,7 @@ class AgreementInfo extends React.Component {
         </Row>
         <Row>
           <Col xs={12}>
-            <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.agreementDescription' })}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.agreements.agreementDescription" />}>
               <div data-test-agreement-description>
                 {agreement.description}
               </div>
@@ -69,21 +68,21 @@ class AgreementInfo extends React.Component {
         </Row>
         <Row>
           <Col xs={4}>
-            <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.cancellationDeadline' })}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.agreements.cancellationDeadline" />}>
               <div data-test-agreement-cancellation-deadline>
-                {agreement.cancellationDeadline ? intl.formatDate(agreement.cancellationDeadline) : '-'}
+                {agreement.cancellationDeadline ? <FormattedDate value={agreement.cancellationDeadline} /> : '-'}
               </div>
             </KeyValue>
           </Col>
           <Col xs={4}>
-            <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.renewalPriority' })}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.agreements.renewalPriority" />}>
               <div data-test-agreement-renewal-priority>
                 {get(agreement, ['renewalPriority', 'label'], '-')}
               </div>
             </KeyValue>
           </Col>
           <Col xs={4}>
-            <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.isPerpetual' })}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.agreements.isPerpetual" />}>
               <div data-test-agreement-is-perpetual>
                 {get(agreement, ['isPerpetual', 'label'], '-')}
               </div>
@@ -95,7 +94,7 @@ class AgreementInfo extends React.Component {
             <AccordionSet>
               <Accordion
                 id="internalContacts"
-                label={intl.formatMessage({ id: 'ui-agreements.agreements.internalContacts' })}
+                label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}
                 onToggle={this.handleSectionToggle}
                 open={this.state.sections.internalContacts}
               >
@@ -103,7 +102,7 @@ class AgreementInfo extends React.Component {
               </Accordion>
               <Accordion
                 id="contentReviews"
-                label={intl.formatMessage({ id: 'ui-agreements.agreements.contentReviews' })}
+                label={<FormattedMessage id="ui-agreements.agreements.contentReviews" />}
                 onToggle={this.handleSectionToggle}
                 open={this.state.sections.contentReviews}
               >
@@ -111,7 +110,7 @@ class AgreementInfo extends React.Component {
               </Accordion>
               <Accordion
                 id="trials"
-                label={intl.formatMessage({ id: 'ui-agreements.agreements.trials' })}
+                label={<FormattedMessage id="ui-agreements.agreements.trials" />}
                 onToggle={this.handleSectionToggle}
                 open={this.state.sections.trials}
               >
@@ -119,7 +118,7 @@ class AgreementInfo extends React.Component {
               </Accordion>
               <Accordion
                 id="reviewHistory"
-                label={intl.formatMessage({ id: 'ui-agreements.agreements.reviewHistory' })}
+                label={<FormattedMessage id="ui-agreements.agreements.reviewHistory" />}
                 onToggle={this.handleSectionToggle}
                 open={this.state.sections.reviewHistory}
               >
@@ -132,5 +131,3 @@ class AgreementInfo extends React.Component {
     );
   }
 }
-
-export default injectIntl(AgreementInfo);

--- a/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
-class AssociatedAgreements extends React.Component {
+export default class AssociatedAgreements extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.assocAgreements' })}
+        label={<FormattedMessage id="ui-agreements.agreements.assocAgreements" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -26,5 +23,3 @@ class AssociatedAgreements extends React.Component {
     );
   }
 }
-
-export default injectIntl(AssociatedAgreements);

--- a/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AssociatedAgreements.js
@@ -5,7 +5,6 @@ import { Accordion } from '@folio/stripes/components';
 
 class AssociatedAgreements extends React.Component {
   static propTypes = {
-    agreement: PropTypes.object,
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -13,7 +12,7 @@ class AssociatedAgreements extends React.Component {
   };
 
   render() {
-    const { agreement, intl } = this.props;
+    const { intl } = this.props;
 
     return (
       <Accordion

--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Accordion, Col, Row } from '@folio/stripes/components';
 
 import EresourceAgreementLines from './EresourceAgreementLines';
 import EresourcesCovered from './EresourcesCovered';
 
-class Eresources extends React.Component {
+export default class Eresources extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   state = {
@@ -25,12 +24,10 @@ class Eresources extends React.Component {
   }
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.eresourceAgreementLines' })}
+        label={<FormattedMessage id="ui-agreements.agreements.eresourceAgreementLines" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -41,7 +38,7 @@ class Eresources extends React.Component {
         </Row>
         <Accordion
           id="eresources-covered"
-          label={intl.formatMessage({ id: 'ui-agreements.agreements.eresourcesCovered' })}
+          label={<FormattedMessage id="ui-agreements.agreements.eresourcesCovered" />}
           open={this.state.eResourcesCoveredOpen}
           onToggle={this.onToggleEresourcesCovered}
         >
@@ -55,5 +52,3 @@ class Eresources extends React.Component {
     );
   }
 }
-
-export default injectIntl(Eresources);

--- a/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
@@ -1,20 +1,9 @@
 import React from 'react';
-import { injectIntl, intlShape } from 'react-intl';
-import PropTypes from 'prop-types';
 
-class EresourcesCovered extends React.Component {
-  static propTypes = {
-    agreementLines: PropTypes.arrayOf(PropTypes.object),
-    intl: intlShape,
-  };
-
+export default class EresourcesCovered extends React.Component {
   render() {
-    const { agreementLines, intl } = this.props;
-
     return (
       <div>TBD</div>
     );
   }
 }
-
-export default injectIntl(EresourcesCovered);

--- a/src/components/Agreements/ViewAgreement/Sections/License.js
+++ b/src/components/Agreements/ViewAgreement/Sections/License.js
@@ -5,7 +5,6 @@ import { Accordion } from '@folio/stripes/components';
 
 class License extends React.Component {
   static propTypes = {
-    agreement: PropTypes.object,
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -13,7 +12,7 @@ class License extends React.Component {
   };
 
   render() {
-    const { agreement, intl } = this.props;
+    const { intl } = this.props;
 
     return (
       <Accordion

--- a/src/components/Agreements/ViewAgreement/Sections/License.js
+++ b/src/components/Agreements/ViewAgreement/Sections/License.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
-class License extends React.Component {
+export default class License extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.license' })}
+        label={<FormattedMessage id="ui-agreements.agreements.license" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -26,5 +23,3 @@ class License extends React.Component {
     );
   }
 }
-
-export default injectIntl(License);

--- a/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
+++ b/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
-class LicenseBusinessTerms extends React.Component {
+export default class LicenseBusinessTerms extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.licenseAndBusTerms' })}
+        label={<FormattedMessage id="ui-agreements.agreements.licenseAndBusTerms" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -26,5 +23,3 @@ class LicenseBusinessTerms extends React.Component {
     );
   }
 }
-
-export default injectIntl(LicenseBusinessTerms);

--- a/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
+++ b/src/components/Agreements/ViewAgreement/Sections/LicenseBusinessTerms.js
@@ -5,7 +5,6 @@ import { Accordion } from '@folio/stripes/components';
 
 class LicenseBusinessTerms extends React.Component {
   static propTypes = {
-    agreement: PropTypes.object,
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -13,7 +12,7 @@ class LicenseBusinessTerms extends React.Component {
   };
 
   render() {
-    const { agreement, intl } = this.props;
+    const { intl } = this.props;
 
     return (
       <Accordion

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -5,7 +5,6 @@ import { Accordion } from '@folio/stripes/components';
 
 class Organizations extends React.Component {
   static propTypes = {
-    agreement: PropTypes.object,
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -13,7 +12,7 @@ class Organizations extends React.Component {
   };
 
   render() {
-    const { agreement, intl } = this.props;
+    const { intl } = this.props;
 
     return (
       <Accordion

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Accordion } from '@folio/stripes/components';
 
-class Organizations extends React.Component {
+export default class Organizations extends React.Component {
   static propTypes = {
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   render() {
-    const { intl } = this.props;
-
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.agreements.organizations' })}
+        label={<FormattedMessage id="ui-agreements.agreements.organizations" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -26,5 +23,3 @@ class Organizations extends React.Component {
     );
   }
 }
-
-export default injectIntl(Organizations);

--- a/src/components/Agreements/ViewAgreement/Sections/VendorInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/VendorInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 
 import {
   Button,
@@ -13,42 +13,41 @@ import {
 
 import css from './VendorInfo.css';
 
-class VendorInfo extends React.Component {
+export default class VendorInfo extends React.Component {
   static propTypes = {
     agreement: PropTypes.object,
-    intl: intlShape,
   };
 
   render() {
-    const { agreement, intl } = this.props;
+    const { agreement } = this.props;
     const { startDate, endDate } = agreement;
 
     return (
       <Row className={css.vendorInfo}>
         <Col xs={3}>
-          <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.vendorInfo.vendor' })}>
+          <KeyValue label={<FormattedMessage id="ui-agreements.agreements.vendorInfo.vendor" />}>
             <div data-test-agreement-vendor-name>{get(agreement, ['vendor', 'name'], '-')}</div>
           </KeyValue>
         </Col>
         <Col xs={2}>
-          <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.startDate' })}>
-            <div data-test-agreement-start-date>{startDate ? intl.formatDate(startDate) : '-'}</div>
+          <KeyValue label={<FormattedMessage id="ui-agreements.agreements.startDate" />}>
+            <div data-test-agreement-start-date>{startDate ? <FormattedDate value={startDate} /> : '-'}</div>
           </KeyValue>
         </Col>
         <Col xs={2}>
-          <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.endDate' })}>
-            <div data-test-agreement-end-date>{endDate ? intl.formatDate(endDate) : '-'}</div>
+          <KeyValue label={<FormattedMessage id="ui-agreements.agreements.endDate" />}>
+            <div data-test-agreement-end-date>{endDate ? <FormattedDate value={endDate} /> : '-'}</div>
           </KeyValue>
         </Col>
         <Col xs={2}>
-          <KeyValue label={intl.formatMessage({ id: 'ui-agreements.agreements.vendorInfo.status' })}>
+          <KeyValue label={<FormattedMessage id="ui-agreements.agreements.vendorInfo.status" />}>
             <div data-test-agreement-status>{get(agreement, ['agreementStatus', 'label'], '-')}</div>
           </KeyValue>
         </Col>
         <Col xs={3}>
           <Button>
             <Icon size="small" icon="external-link">
-              {intl.formatMessage({ id: 'ui-agreements.agreements.vendorInfo.visitPlatform' })}
+              <FormattedMessage id="ui-agreements.agreements.vendorInfo.visitPlatform" />
             </Icon>
           </Button>
         </Col>
@@ -56,5 +55,3 @@ class VendorInfo extends React.Component {
     );
   }
 }
-
-export default injectIntl(VendorInfo);

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 
 import {
   AccordionSet,
@@ -131,12 +132,12 @@ class ViewAgreement extends React.Component {
   }
 
   renderEditLayer() {
-    const { resources: { query }, stripes: { intl } } = this.props;
+    const { resources: { query } } = this.props;
 
     return (
       <Layer
         isOpen={query.layer === 'edit'}
-        contentLabel={intl.formatMessage({ id: 'ui-agreements.agreements.editAgreement' })}
+        contentLabel={<FormattedMessage id="ui-agreements.agreements.editAgreement" />}
       >
         <EditAgreement
           {...this.props}
@@ -167,8 +168,7 @@ class ViewAgreement extends React.Component {
         onClose={this.props.onClose}
         actionMenuItems={stripes.hasPerm('ui-agreements.agreements.edit') ? [{
           id: 'clickable-edit-agreement',
-          title: stripes.intl.formatMessage({ id: 'ui-agreements.agreements.editAgreement' }),
-          label: stripes.intl.formatMessage({ id: 'ui-agreements.agreements.edit' }),
+          label: <FormattedMessage id="ui-agreements.agreements.edit" />,
           href: this.props.editLink,
           onClick: this.props.onEdit,
           icon: 'edit',

--- a/src/components/BasketSelector/BasketSelector.js
+++ b/src/components/BasketSelector/BasketSelector.js
@@ -5,7 +5,7 @@ import BasketSelectorContainer from './BasketSelectorContainer';
 
 class BasketSelector extends React.Component {
   static propTypes = {
-    addButtonLabel: PropTypes.string,
+    addButtonLabel: PropTypes.node,
     onAdd: PropTypes.func,
     stripes: PropTypes.shape({
       connect: PropTypes.func,

--- a/src/components/BasketSelector/BasketSelectorDisplay.js
+++ b/src/components/BasketSelector/BasketSelectorDisplay.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Button,
@@ -10,15 +10,14 @@ import {
   Select,
 } from '@folio/stripes/components';
 
-class BasketSelectorDisplay extends React.Component {
+export default class BasketSelectorDisplay extends React.Component {
   static manifest = Object.freeze({
     basket: { initialValue: [] },
   });
 
   static propTypes = {
-    addButtonLabel: PropTypes.string,
+    addButtonLabel: PropTypes.node,
     basket: PropTypes.arrayOf(PropTypes.object),
-    intl: intlShape,
     onAdd: PropTypes.func,
   }
 
@@ -35,7 +34,7 @@ class BasketSelectorDisplay extends React.Component {
   }
 
   render() {
-    const { addButtonLabel, basket, intl, onAdd } = this.props;
+    const { addButtonLabel, basket, onAdd } = this.props;
     const { item } = this.state;
 
     const dataOptions = [
@@ -49,14 +48,18 @@ class BasketSelectorDisplay extends React.Component {
     return (
       <Row>
         <Col xs={12} md={8}>
-          <Select
-            dataOptions={dataOptions}
-            id="basket-selector"
-            label={intl.formatMessage({ id: 'ui-agreements.basketSelector.selectLabel' })}
-            onChange={this.handleChange}
-            placeholder={intl.formatMessage({ id: 'ui-agreements.basketSelector.selectPlaceholder' })}
-            value={item.id}
-          />
+          <FormattedMessage id="ui-agreements.basketSelector.selectPlaceholder">
+            {placeholder => (
+              <Select
+                dataOptions={dataOptions}
+                id="basket-selector"
+                label={<FormattedMessage id="ui-agreements.basketSelector.selectLabel" />}
+                onChange={this.handleChange}
+                placeholder={placeholder}
+                value={item.id}
+              />
+            )}
+          </FormattedMessage>
         </Col>
         <Col xs={12} md={4}>
           <Layout style={{ height: '100%' }} className="flex flex-direction-column justify-end">
@@ -75,5 +78,3 @@ class BasketSelectorDisplay extends React.Component {
     );
   }
 }
-
-export default injectIntl(BasketSelectorDisplay);

--- a/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
+++ b/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import Link from 'react-router-dom/Link';
+import { injectIntl, intlShape } from 'react-intl';
 import {
   Accordion,
   Col,
@@ -24,6 +25,7 @@ class AcquisitionOptions extends React.Component {
   static propTypes = {
     eresource: PropTypes.object,
     id: PropTypes.string,
+    intl: intlShape,
     match: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     onToggle: PropTypes.func,
     open: PropTypes.bool,
@@ -40,7 +42,7 @@ class AcquisitionOptions extends React.Component {
   }
 
   render() {
-    const { eresource, resources: { entitlementOptions }, stripes: { intl } } = this.props;
+    const { eresource, resources: { entitlementOptions }, intl } = this.props;
 
     if (!entitlementOptions || !entitlementOptions.records) {
       return <Icon icon="spinner-ellipsis" width="100px" />;
@@ -105,4 +107,4 @@ class AcquisitionOptions extends React.Component {
   }
 }
 
-export default AcquisitionOptions;
+export default injectIntl(AcquisitionOptions);

--- a/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
+++ b/src/components/EResources/ViewEResource/Sections/AcquisitionOptions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import Link from 'react-router-dom/Link';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import {
   Accordion,
   Col,
@@ -51,7 +51,7 @@ class AcquisitionOptions extends React.Component {
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.eresources.acqOptions' }, eresource)}
+        label={<FormattedMessage id="ui-agreements.eresources.acqOptions" values={{ eresource }} />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
@@ -70,8 +70,8 @@ class AcquisitionOptions extends React.Component {
                   const optionIsPackage = isPackage(option);
 
                   const addLabel = optionIsPackage ?
-                    intl.formatMessage({ id: 'ui-agreements.eresources.addPackage' }) :
-                    intl.formatMessage({ id: 'ui-agreements.eresources.addTitle' });
+                    <FormattedMessage id="ui-agreements.eresources.addPackage" /> :
+                    <FormattedMessage id="ui-agreements.eresources.addTitle" />;
 
                   const buttonProps = optionIsPackage ?
                     { 'data-test-add-package-to-basket': true } :

--- a/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceAgreements.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
+import { injectIntl, intlShape } from 'react-intl';
 import {
   Col,
   Icon,
@@ -22,16 +23,16 @@ class EResourceAgreements extends React.Component {
   })
 
   static propTypes = {
+    intl: intlShape,
     match: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     resources: PropTypes.shape({
       entitlements: PropTypes.object,
     }),
-    stripes: PropTypes.object,
   };
 
 
   render() {
-    const { resources: { entitlements }, stripes: { intl } } = this.props;
+    const { resources: { entitlements }, intl } = this.props;
 
     if (!entitlements || !entitlements.records) {
       return <Icon icon="spinner-ellipsis" width="100px" />;
@@ -68,4 +69,4 @@ class EResourceAgreements extends React.Component {
   }
 }
 
-export default EResourceAgreements;
+export default injectIntl(EResourceAgreements);

--- a/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
+++ b/src/components/EResources/ViewEResource/Sections/EResourceInfo.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Accordion,
@@ -13,14 +13,13 @@ import {
 
 import { EResourceAgreements } from '.';
 
-class EResourceInfo extends React.Component {
+export default class EResourceInfo extends React.Component {
   static propTypes = {
     eresource: PropTypes.object,
     id: PropTypes.string,
     match: PropTypes.object,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
-    intl: intlShape,
   };
 
   constructor(props) {
@@ -41,37 +40,37 @@ class EResourceInfo extends React.Component {
   }
 
   render() {
-    const { eresource, intl } = this.props;
+    const { eresource } = this.props;
 
     return (
       <Accordion
         id={this.props.id}
-        label={intl.formatMessage({ id: 'ui-agreements.eresources.erInfo' })}
+        label={<FormattedMessage id="ui-agreements.eresources.erInfo" />}
         open={this.props.open}
         onToggle={this.props.onToggle}
       >
         <Row>
           <Col xs={4}>
             <KeyValue
-              label={intl.formatMessage({ id: 'ui-agreements.eresources.erType' })}
+              label={<FormattedMessage id="ui-agreements.eresources.erType" />}
               value={get(eresource, ['type', 'label'], '-')}
             />
           </Col>
           <Col xs={4}>
             <KeyValue
-              label={intl.formatMessage({ id: 'ui-agreements.eresources.publisher' })}
+              label={<FormattedMessage id="ui-agreements.eresources.publisher" />}
               value={get(eresource, ['publisher', 'label'], '-')}
             />
           </Col>
           <Col xs={2}>
             <KeyValue
-              label={intl.formatMessage({ id: 'ui-agreements.eresources.pIssn' })}
+              label={<FormattedMessage id="ui-agreements.eresources.pIssn" />}
               value={this.getIdentifier('pissn')}
             />
           </Col>
           <Col xs={2}>
             <KeyValue
-              label={intl.formatMessage({ id: 'ui-agreements.eresources.eIssn' })}
+              label={<FormattedMessage id="ui-agreements.eresources.eIssn" />}
               value={this.getIdentifier('eissn')}
             />
           </Col>
@@ -87,5 +86,3 @@ class EResourceInfo extends React.Component {
     );
   }
 }
-
-export default injectIntl(EResourceInfo);

--- a/src/components/KBs/ViewKB/ViewKB.js
+++ b/src/components/KBs/ViewKB/ViewKB.js
@@ -17,8 +17,6 @@ export default class ViewKB extends React.Component {
   });
 
   static propTypes = {
-    parentResources: PropTypes.object,
-    match: PropTypes.object,
     paneWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onClose: PropTypes.func,
   };

--- a/src/components/Titles/ViewTitle/ViewTitle.js
+++ b/src/components/Titles/ViewTitle/ViewTitle.js
@@ -17,7 +17,6 @@ export default class ViewTitle extends React.Component {
   });
 
   static propTypes = {
-    match: PropTypes.object,
     paneWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onClose: PropTypes.func,
   };

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import { injectIntl, intlShape } from 'react-intl';
 
 import { SearchAndSort } from '@folio/stripes/smart-components';
 
@@ -74,9 +75,9 @@ class Agreements extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape,
     resources: PropTypes.object,
     mutator: PropTypes.object,
-    stripes: PropTypes.object,
   };
 
   componentDidUpdate() {
@@ -100,7 +101,7 @@ class Agreements extends React.Component {
 
     // If we've fetched the records for every filter...
     if (records.every(record => record.length)) {
-      const { stripes: { intl } } = this.props;
+      const { intl } = this.props;
       // ...then for every filter...
       filters.forEach((filter, i) => {
         // ...set the filter's `values` and `label` properties
@@ -132,7 +133,7 @@ class Agreements extends React.Component {
   }
 
   render() {
-    const { mutator, resources, stripes: { intl } } = this.props;
+    const { mutator, resources, intl } = this.props;
     const path = '/erm/agreements';
     packageInfo.stripes.route = path;
     packageInfo.stripes.home = path;
@@ -206,4 +207,4 @@ class Agreements extends React.Component {
   }
 }
 
-export default Agreements;
+export default injectIntl(Agreements);

--- a/src/routes/EResources.js
+++ b/src/routes/EResources.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
+import { injectIntl, intlShape } from 'react-intl';
 
 import { SearchAndSort } from '@folio/stripes/smart-components';
 
@@ -55,13 +56,13 @@ class EResources extends React.Component {
   });
 
   static propTypes = {
+    intl: intlShape,
     resources: PropTypes.shape({
       eresources: PropTypes.object,
       eresourceFiltersInitialized: PropTypes.bool,
       typeValues: PropTypes.object,
     }),
     mutator: PropTypes.object,
-    stripes: PropTypes.object,
   };
 
   componentDidUpdate() {
@@ -81,7 +82,7 @@ class EResources extends React.Component {
 
     // If we've fetched the records for every filter...
     if (records.every(record => record.length)) {
-      const { stripes: { intl } } = this.props;
+      const { intl } = this.props;
       // ...then for every filter...
       filters.forEach((filter, i) => {
         // ...set the filter's `values` and `label` properties
@@ -101,7 +102,7 @@ class EResources extends React.Component {
   }
 
   render() {
-    const { mutator, resources, stripes: { intl } } = this.props;
+    const { mutator, resources, intl } = this.props;
     const path = '/erm/eresources';
     packageInfo.stripes.route = path;
     packageInfo.stripes.home = path;
@@ -150,4 +151,4 @@ class EResources extends React.Component {
   }
 }
 
-export default EResources;
+export default injectIntl(EResources);

--- a/src/routes/KBs.js
+++ b/src/routes/KBs.js
@@ -35,6 +35,7 @@ export default class KBs extends React.Component {
   });
 
   static propTypes = {
+    mutator: PropTypes.object,
     resources: PropTypes.shape({
       records: PropTypes.arrayOf(PropTypes.object),
     }),

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
@@ -13,12 +14,12 @@ export default class ErmSettings extends React.Component {
   pages = [
     {
       route: 'general',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-agreements.settings.general' }),
+      label: <FormattedMessage id="ui-agreements.settings.general" />,
       component: GeneralSettings,
     },
     {
       route: 'somefeature',
-      label: this.props.stripes.intl.formatMessage({ id: 'ui-agreements.settings.some-feature' }),
+      label: <FormattedMessage id="ui-agreements.settings.some-feature" />,
       component: SomeFeatureSettings,
     },
   ];


### PR DESCRIPTION
## Purpose
https://github.com/folio-org/stripes-core/pull/489

Retrieving the `intl` object from `this.context.intl` or the `stripes` god object (`stripes.intl`) is a deprecated pattern.

## Approach
Use `<FormattedMessage>`, `<FormattedDate>`, and `<FormattedTime>` as often as possible, only falling back to `formatMessage()`, `formatDate()`, and `formatTime()` (accompanied by `injectIntl()`) when a bare string is absolutely necessary.

## Future work
`MultiColumnList` has some challenges receiving nodes in `columnMapping`, so I had to leave those `formatMessage()` uses alone for now: https://issues.folio.org/browse/STCOM-399