### PR TITLE
Release 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change history for ui-agreements
 
-## 1.1.0 (IN PROGRESS)
+## 1.2.0 (IN PROGRESS)
+
+## 1.1.0
+* Added Basket
+* Removed Titles and KB views.
+* Added ability to add entitlements to Agreements
+* Added ability to add organizations to Agreements
 
 ## 1.0.0
 
@@ -9,4 +15,3 @@
 * Added Agreement detail view.
 * Added Agreement lines view.
 * Added E-resources pane, list, and detail view.
-* Added ability to add e-resources to cart.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "@folio/stripes-cli": "^1.5.0",
     "@folio/stripes": "^1.1.0",
     "babel-eslint": "^9.0.0",
-    "eslint": "^5.5.0"
+    "eslint": "^5.5.0",
+    "react": "~16.6.3",
+    "react-dom": "~16.6.3",
+    "react-redux": "~5.1.1",
+    "redux": "~3.7.2"
   },
   "dependencies": {
     "lodash": "^4.17.4",
@@ -35,8 +39,11 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^1.0.0",
-    "react": "*"
-  },
+    "react": "~16.6.3",
+    "react-dom": "~16.6.3",
+    "react-redux": "~5.1.1",
+    "redux": "~3.7.2"
+    },
   "stripes": {
     "type": "app",
     "displayName": "ui-agreements.meta.title",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^1.0.0",
-    "react": "~16.6.3",
-    "react-dom": "~16.6.3",
-    "react-redux": "~5.1.1",
-    "redux": "~3.7.2"
-    },
+    "react": "*",
+    "react-dom": "*",
+    "react-redux": "*",
+    "redux": "*"
+  },
   "stripes": {
     "type": "app",
     "displayName": "ui-agreements.meta.title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/agreements",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ERM functionality for Stripes",
   "main": "src/index.js",
   "publishConfig": {
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes-cli": "^1.5.0",
-    "@folio/stripes": "^1.0.0",
+    "@folio/stripes": "^1.1.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0"
   },


### PR DESCRIPTION
- Mainly to fix the issue of wrong version numbers being pushed to the folioci NPM registry
- Took the opportunity to bump to `@folio/stripes` 1.1