### PR TITLE
Organization Selection with an async options list

### DIFF
--- a/src/components/Agreements/AgreementForm/AgreementForm.js
+++ b/src/components/Agreements/AgreementForm/AgreementForm.js
@@ -15,9 +15,9 @@ import {
 class AgreementForm extends React.Component {
   state = {
     sections: {
-      agreementFormInfo: false,
+      agreementFormInfo: true,
       agreementFormEresources: false,
-      agreementFormOrganizations: true,
+      agreementFormOrganizations: false,
     }
   }
 

--- a/src/components/Agreements/AgreementForm/AgreementForm.js
+++ b/src/components/Agreements/AgreementForm/AgreementForm.js
@@ -26,6 +26,7 @@ class AgreementForm extends React.Component {
       agreementLines: this.props.agreementLines,
       onToggle: this.handleSectionToggle,
       parentResources: this.props.parentResources,
+      parentMutator: this.props.parentMutator,
       stripes: this.props.stripes,
     };
   }

--- a/src/components/Agreements/AgreementForm/AgreementForm.js
+++ b/src/components/Agreements/AgreementForm/AgreementForm.js
@@ -15,9 +15,9 @@ import {
 class AgreementForm extends React.Component {
   state = {
     sections: {
-      agreementFormInfo: true,
+      agreementFormInfo: false,
       agreementFormEresources: false,
-      agreementFormOrganizations: false,
+      agreementFormOrganizations: true,
     }
   }
 

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
@@ -83,7 +83,6 @@ class AgreementFormOrganizations extends React.Component {
                 <Field
                   component={OrganizationSelection}
                   name={`orgs[${index}].org`}
-                  stripes={this.props.stripes}
                 />
               </Col>
               <Col xs={3}>

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
@@ -23,7 +23,7 @@ class AgreementFormOrganizations extends React.Component {
     onToggle: PropTypes.func,
     open: PropTypes.bool,
     parentResources: PropTypes.shape({
-      orgs: PropTypes.object,
+      orgRoleValues: PropTypes.object,
     }),
     stripes: PropTypes.shape({
       connect: PropTypes.func,

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
@@ -25,11 +25,6 @@ class AgreementFormOrganizations extends React.Component {
     parentResources: PropTypes.shape({
       orgs: PropTypes.object,
     }),
-    parentMutator: PropTypes.shape({
-      orgNameFilter: PropTypes.shape({
-        replace: PropTypes.func,
-      }),
-    }),
     stripes: PropTypes.shape({
       connect: PropTypes.func,
     }),

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -105,7 +105,7 @@ class ViewAgreement extends React.Component {
     if (orgs && orgs.length) {
       agreement.orgs = orgs.map(o => ({
         ...o,
-        org: o.org.id,
+        // org: o.org.id,
         role: o.role ? o.role.label : undefined,
       }));
     }
@@ -166,7 +166,14 @@ class ViewAgreement extends React.Component {
               agreement={this.getAgreement()}
               agreementLines={this.getAgreementLines()}
               onCancel={this.props.onCloseEdit}
-              parentMutator={this.props.mutator}
+              parentMutator={{
+                ...this.props.parentMutator,
+                ...this.props.mutator
+              }}
+              parentResources={{
+                ...this.props.parentResources,
+                ...this.props.resources
+              }}
               initialValues={this.getInitialValues()}
             />
           </Layer>

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -105,7 +105,6 @@ class ViewAgreement extends React.Component {
     if (orgs && orgs.length) {
       agreement.orgs = orgs.map(o => ({
         ...o,
-        // org: o.org.id,
         role: o.role ? o.role.label : undefined,
       }));
     }

--- a/src/components/OrganizationSelection/OrganizationSelection.js
+++ b/src/components/OrganizationSelection/OrganizationSelection.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { withStripes } from '@folio/stripes/core';
 
 import OrganizationSelectionContainer from './OrganizationSelectionContainer';
 
-export default class OrganizationSelection extends React.Component {
+class OrganizationSelection extends React.Component {
   static propTypes = {
     input: PropTypes.shape({
       name: PropTypes.string,
@@ -26,3 +27,5 @@ export default class OrganizationSelection extends React.Component {
     return <this.connectedOrganizationSelectionContainer {...this.props} />;
   }
 }
+
+export default withStripes(OrganizationSelection);

--- a/src/components/OrganizationSelection/OrganizationSelection.js
+++ b/src/components/OrganizationSelection/OrganizationSelection.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import OrganizationSelectionContainer from './OrganizationSelectionContainer';
+
+export default class OrganizationSelection extends React.Component {
+  static propTypes = {
+    input: PropTypes.shape({
+      name: PropTypes.string,
+    }),
+    stripes: PropTypes.shape({
+      connect: PropTypes.func,
+    }),
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.connectedOrganizationSelectionContainer = props.stripes.connect(
+      OrganizationSelectionContainer,
+      { dataKey: props.input.name }
+    );
+  }
+
+  render() {
+    return <this.connectedOrganizationSelectionContainer {...this.props} />;
+  }
+}

--- a/src/components/OrganizationSelection/OrganizationSelectionContainer.js
+++ b/src/components/OrganizationSelection/OrganizationSelectionContainer.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { debounce, get } from 'lodash';
+
+import OrganizationSelectionDisplay from './OrganizationSelectionDisplay';
+
+export default class OrganizationSelectionContainer extends React.Component {
+  static manifest = Object.freeze({
+    organizations: {
+      type: 'okapi',
+      path: 'erm/org',
+      limitParam: 'perPage',
+      perRequest: 100,
+      params: {
+        match: 'name',
+        term: '${orgNameFilter}', // eslint-disable-line no-template-curly-in-string
+      },
+    },
+    orgNameFilter: { initialValue: '' },
+  });
+
+  static propTypes = {
+    input: PropTypes.shape({
+      onChange: PropTypes.func,
+      value: PropTypes.oneOfType(PropTypes.object, PropTypes.string),
+    }),
+    mutator: PropTypes.shape({
+      orgNameFilter: PropTypes.shape({
+        replace: PropTypes.func,
+      }),
+    }),
+    resources: PropTypes.shape({
+      organizations: PropTypes.object,
+    }),
+  };
+
+  constructor(props) {
+    super(props);
+
+    const { input } = props;
+    const selectedOption = input.value ? { value: input.value.id, label: input.value.name } : undefined;
+    const organizations = selectedOption ? [selectedOption] : [];
+
+    this.state = {
+      organizations,
+      searchString: '',
+      selectedOption, // eslint-disable-line react/no-unused-state
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps, state) {
+    const organizations = get(nextProps.resources.organizations, ['records'], [])
+      .map(({ id, name }) => ({ value: id, label: name }));
+
+    if (state.selectedOption) {
+      organizations.unshift(state.selectedOption);
+    }
+
+    return { organizations };
+  }
+
+  updateOrgNameFilter = debounce(
+    searchString => this.props.mutator.orgNameFilter.replace(searchString),
+    500
+  )
+
+  handleFilter = (searchString) => {
+    this.setState({ searchString });
+    this.updateOrgNameFilter(searchString);
+    return this.state.organizations;
+  }
+
+  handleChange = (value) => {
+    const { organizations } = this.state;
+    this.setState({ selectedOption: organizations.find(o => o.value === value) }); // eslint-disable-line react/no-unused-state
+    this.props.input.onChange(value);
+  }
+
+  render() {
+    return (
+      <OrganizationSelectionDisplay
+        loading={get(this.props.resources, ['organizations', 'isPending'], false)}
+        onChange={this.handleChange}
+        onFilter={this.handleFilter}
+        organizations={this.state.organizations}
+        searchString={this.state.searchString}
+        value={this.props.input.value.id || this.props.input.value}
+      />
+    );
+  }
+}

--- a/src/components/OrganizationSelection/OrganizationSelectionContainer.js
+++ b/src/components/OrganizationSelection/OrganizationSelectionContainer.js
@@ -13,7 +13,7 @@ export default class OrganizationSelectionContainer extends React.Component {
       perRequest: 100,
       params: {
         match: 'name',
-        term: '${orgNameFilter}', // eslint-disable-line no-template-curly-in-string
+        term: '%{orgNameFilter}',
       },
     },
     orgNameFilter: { initialValue: '' },

--- a/src/components/OrganizationSelection/OrganizationSelectionDisplay.js
+++ b/src/components/OrganizationSelection/OrganizationSelectionDisplay.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Icon,
+  OptionSegment,
+  Selection,
+} from '@folio/stripes/components';
+
+export default class OrganizationSelectionDisplay extends React.Component {
+  static propTypes = {
+    loading: PropTypes.bool,
+    onChange: PropTypes.func,
+    onFilter: PropTypes.func,
+    organizations: PropTypes.arrayOf(
+      PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.string,
+      })
+    ),
+    searchString: PropTypes.string,
+    value: PropTypes.string,
+  };
+
+  render() {
+    const { loading, onChange, onFilter, organizations, searchString, value } = this.props;
+    return (
+      <FormattedMessage id="ui-agreements.organizations.selectOrg">
+        {placeholder => (
+          <Selection
+            component={Selection}
+            dataOptions={organizations}
+            emptyMessage={!searchString ? <FormattedMessage id="ui-agreements.organizations.typeToSearch" /> : undefined}
+            formatter={(props) => {
+              const { option } = props;
+              if (loading || !option) return <Icon icon="spinner-ellipsis" />;
+
+              return <OptionSegment {...props}>{option.label}</OptionSegment>;
+            }}
+            onChange={onChange}
+            onFilter={onFilter}
+            placeholder={placeholder}
+            value={value}
+          />
+        )}
+      </FormattedMessage>
+    );
+  }
+}

--- a/src/components/OrganizationSelection/index.js
+++ b/src/components/OrganizationSelection/index.js
@@ -1,0 +1,1 @@
+export { default } from './OrganizationSelection';

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -47,16 +47,6 @@ class Agreements extends React.Component {
       path: 'erm/sas/${selectedAgreementId}', // eslint-disable-line no-template-curly-in-string
       fetch: false,
     },
-    orgs: {
-      type: 'okapi',
-      path: 'erm/org',
-      limitParam: 'perPage',
-      perRequest: 100,
-      params: {
-        match: 'name',
-        term: '${orgNameFilter}', // eslint-disable-line no-template-curly-in-string
-      },
-    },
     agreementTypeValues: {
       type: 'okapi',
       path: 'erm/refdataValues/SubscriptionAgreement/agreementType',
@@ -83,7 +73,6 @@ class Agreements extends React.Component {
     },
     agreementFiltersInitialized: { initialValue: false },
     basket: { initialValue: [] },
-    orgNameFilter: { initialValue: '' },
     query: {},
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     selectedAgreementId: { initialValue: '' },

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -50,12 +50,11 @@ class Agreements extends React.Component {
     orgs: {
       type: 'okapi',
       path: 'erm/org',
-      records: 'results',
       limitParam: 'perPage',
       perRequest: 100,
-      recordsRequired: '1000',
       params: {
-        stats: 'true',
+        match: 'name',
+        term: '${orgNameFilter}', // eslint-disable-line no-template-curly-in-string
       },
     },
     agreementTypeValues: {
@@ -84,6 +83,7 @@ class Agreements extends React.Component {
     },
     agreementFiltersInitialized: { initialValue: false },
     basket: { initialValue: [] },
+    orgNameFilter: { initialValue: '' },
     query: {},
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     selectedAgreementId: { initialValue: '' },

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -119,6 +119,7 @@
   "organizations.selectRole": "Select a role",
   "organizations.createNew": "Create new organization",
   "organizations.alreadyExists": "An organization with this name already exists!",
+  "organizations.typeToSearch": "Begin typing to search for an organization",
 
   "settings.general": "General",
   "settings.general.message": "These are your general app settings.",


### PR DESCRIPTION
**Problem**
Users can add organizations to an agreement. They do so by selecting which organization they want to add to the agreement from a `Selection`'s dropdown. The dropdown's option list was being populated by all the records at the `/erm/org` endpoint. However, that endpoint can return thousands of entries. We want to be able to search that endpoint based on the user's entered text so we can do filtering on the backend rather than locally.

**Solution**
- Create a component `OrganizationSelection` that renders it's descendants `OrganizationSelectionContainer` > `OrganizationSelectionDisplay`.
- `OS` merely `connect()`s `OSC` with a unique `dataKey` generated from the form field's name. This is so we can fetch different sets of orgs for each dropdown.
- `OSC` handles fetching of `/erm/org?our_query`, and translation of the resources to its child, `OSD`. 
  - One strange part is that it always `unshift`s the currently-selected option (not just currently-selected _value_) into the orgs lists that was fetched so that it may be rendered. Which naturally means I need to hold the currently-selected option in `state` manually.
- `OSD` renders the `Selection` itself.

**Note to Reviewers**
I have a feeling we're going to start having these use cases crop up more as we start getting real data and reckoning with the fact that we haven't been assuming large enough datasets. At least, I know _I'm_ going to facing these kinds of scenarios going forward with ERM. So two things are: 
- We might want to consider whether we want to deal with these scenarios manually like I did here or provide some support via Stripes.
- If y'all have a few spare moments, I'd appreciate your peek at it to see if there'd be a more elegant/performant/succinct solution to what I've got going here.

**Screencast:** [imgur gif](https://imgur.com/a/xQzHGIA) 
(Ignore the duplicate entries in the dropdown, it was me messing around creating a bunch of duplicates)
