### PR TITLE
CoverageStatements: Fixed rendering of multiple statements

### DIFF
--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -54,9 +54,9 @@ export default class CoverageStatements extends React.Component {
     if (!statements || !statements.length) return '-';
 
     return (
-      <React.Fragment>
+      <Layout className="flex flex-direction-column flex-align-items-start">
         {statements.map(this.renderStatement)}
-      </React.Fragment>
+      </Layout>
     );
   }
 }


### PR DESCRIPTION
Multiple coverage statements for a single item were being rendered side-by-side rather than above one another. This fixes that.