### PR TITLE
Add okapiInterfaces dependency to interface "erm" version 1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "home": "/erm/agreements?sort=Name&filters=agreementStatus.Requested,agreementStatus.In Negotiation,agreementStatus.Draft,agreementStatus.Active",
     "hasSettings": true,
     "queryResource": "query",
-    "okapiInterfaces": {},
+    "okapiInterfaces": {
+      "erm": "1.0"
+    },
     "permissionSets": [
       {
         "permissionName": "module.agreements.enabled",


### PR DESCRIPTION
This will allow Okapi to pull in the required backend module (mod-agreements) as part of the dependency resolution process. Requesting review, as I'm not sure if there was a reason this was omitted in the first place.

Towards UIER-30.