### PR TITLE
Show item counts in accordion header

### DIFF
--- a/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AgreementInfo.js
@@ -77,18 +77,10 @@ export default class AgreementInfo extends React.Component {
         <Row className={css.agreementInfoSections}>
           <Col xs={12}>
             <AccordionSet>
-              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}>
-                <InternalContacts key={agreement.id} {...this.props} />
-              </Accordion>
-              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.contentReviews" />}>
-                -
-              </Accordion>
-              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.trials" />}>
-                -
-              </Accordion>
-              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.reviewHistory" />}>
-                -
-              </Accordion>
+              <InternalContacts key={agreement.id} {...this.props} />
+              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.contentReviews" />}>-</Accordion>
+              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.trials" />}>-</Accordion>
+              <Accordion closedByDefault label={<FormattedMessage id="ui-agreements.agreements.reviewHistory" />}>-</Accordion>
             </AccordionSet>
           </Col>
         </Row>

--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Accordion } from '@folio/stripes/components';
+import { Accordion, Badge, Icon } from '@folio/stripes/components';
 
 import EresourceAgreementLines from './EresourceAgreementLines';
 import EresourcesCovered from './EresourcesCovered';
@@ -14,19 +15,13 @@ export default class Eresources extends React.Component {
     open: PropTypes.bool,
   };
 
-  state = {
-    eResourcesCoveredOpen: true,
-  }
-
-  onToggleEresourcesCovered = () => {
-    this.setState((prevState) => ({
-      eResourcesCoveredOpen: !prevState.eResourcesCoveredOpen,
-    }));
+  renderBadge = () => {
+    const count = get(this.props.agreementLines, ['length']);
+    return count !== undefined ? <Badge>{count}</Badge> : <Icon icon="spinner-ellipsis" width="10px" />;
   }
 
   render() {
     const { id, onToggle, open } = this.props;
-    const { eResourcesCoveredOpen } = this.state;
 
     return (
       <Accordion
@@ -34,22 +29,17 @@ export default class Eresources extends React.Component {
         label={<FormattedMessage id="ui-agreements.agreements.eresourceAgreementLines" />}
         open={open}
         onToggle={onToggle}
+        displayWhenClosed={this.renderBadge()}
+        displayWhenOpen={this.renderBadge()}
       >
         <EresourceAgreementLines
           visible={open}
           {...this.props}
         />
-        <Accordion
-          id="eresources-covered"
-          label={<FormattedMessage id="ui-agreements.agreements.eresourcesCovered" />}
-          open={eResourcesCoveredOpen}
-          onToggle={this.onToggleEresourcesCovered}
-        >
-          <EresourcesCovered
-            visible={open && eResourcesCoveredOpen}
-            {...this.props}
-          />
-        </Accordion>
+        <EresourcesCovered
+          visible={open}
+          {...this.props}
+        />
       </Accordion>
     );
   }

--- a/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { MultiColumnList } from '@folio/stripes/components';
+import { Accordion, Badge, Icon, MultiColumnList } from '@folio/stripes/components';
 
 import CoverageStatements from '../../../CoverageStatements';
 import EResourceLink from '../../../EResourceLink';
@@ -15,6 +15,10 @@ export default class EresourcesCovered extends React.Component {
     }),
     visible: PropTypes.bool,
   };
+
+  state = {
+    open: true,
+  }
 
   columnMapping = {
     name: <FormattedMessage id="ui-agreements.eresources.name" />,
@@ -49,21 +53,41 @@ export default class EresourcesCovered extends React.Component {
     'coverage',
   ]
 
+  onToggleAccordion = () => {
+    this.setState((prevState) => ({
+      open: !prevState.open,
+    }));
+  }
+
+  renderBadge = () => {
+    const count = get(this.props.parentResources, ['agreementEresources', 'records', 'length']);
+    return count !== undefined ? <Badge>{count}</Badge> : <Icon icon="spinner-ellipsis" width="10px" />;
+  }
+
   render() {
     const agreementEresources = get(this.props.parentResources, ['agreementEresources', 'records'], []);
 
     return (
-      <MultiColumnList
-        columnMapping={this.columnMapping}
-        contentData={this.props.visible ? agreementEresources : []}
-        formatter={this.formatter}
-        height={800}
+      <Accordion
+        displayWhenClosed={this.renderBadge()}
+        displayWhenOpen={this.renderBadge()}
         id="eresources-covered"
-        interactive={false}
-        onNeedMoreData={this.props.fetchMoreEresources}
-        virtualize
-        visibleColumns={this.visibleColumns}
-      />
+        label={<FormattedMessage id="ui-agreements.agreements.eresourcesCovered" />}
+        open={this.state.open}
+        onToggle={this.onToggleAccordion}
+      >
+        <MultiColumnList
+          columnMapping={this.columnMapping}
+          contentData={this.props.visible && this.state.open ? agreementEresources : []}
+          formatter={this.formatter}
+          height={800}
+          id="eresources-covered"
+          interactive={false}
+          onNeedMoreData={this.props.fetchMoreEresources}
+          virtualize
+          visibleColumns={this.visibleColumns}
+        />
+      </Accordion>
     );
   }
 }

--- a/src/components/Agreements/ViewAgreement/Sections/InternalContacts.js
+++ b/src/components/Agreements/ViewAgreement/Sections/InternalContacts.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 
-import {
-  Icon
-} from '@folio/stripes/components';
+import { Accordion, Badge, Icon } from '@folio/stripes/components';
 
 export default class InternalContacts extends React.Component {
   static propTypes = {
@@ -25,7 +24,12 @@ export default class InternalContacts extends React.Component {
     <Icon icon="spinner-ellipsis" width="100px" />
   );
 
-  render() {
+  renderBadge = () => {
+    const count = get(this.props.contacts, ['length']);
+    return count !== undefined ? <Badge>{count}</Badge> : <Icon icon="spinner-ellipsis" width="10px" />;
+  }
+
+  renderContacts = () => {
     const { contacts } = this.props;
     if (contacts === undefined) return this.renderSpinner();
 
@@ -45,5 +49,18 @@ export default class InternalContacts extends React.Component {
         </div>
       );
     });
+  }
+
+  render() {
+    return (
+      <Accordion
+        closedByDefault
+        displayWhenClosed={this.renderBadge()}
+        displayWhenOpen={this.renderBadge()}
+        label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}
+      >
+        { this.renderContacts() }
+      </Accordion>
+    );
   }
 }

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
-import { Accordion, Layout } from '@folio/stripes/components';
+import { Accordion, Badge, Icon, Layout } from '@folio/stripes/components';
 
 export default class Organizations extends React.Component {
   static propTypes = {
@@ -66,10 +67,17 @@ export default class Organizations extends React.Component {
     return <FormattedMessage id="ui-agreements.license.noLicenseOrganizations" />;
   }
 
+  renderBadge = () => {
+    const count = get(this.props.agreement, ['orgs', 'length']);
+    return count !== undefined ? <Badge>{count}</Badge> : <Icon icon="spinner-ellipsis" width="10px" />;
+  }
+
   render() {
     return (
       <Accordion
         id={this.props.id}
+        displayWhenClosed={this.renderBadge()}
+        displayWhenOpen={this.renderBadge()}
         label={<FormattedMessage id="ui-agreements.agreements.organizations" />}
         open={this.props.open}
         onToggle={this.props.onToggle}


### PR DESCRIPTION
The agreement view pane has a bunch of accordions, some of which show lists of items such as internal contacts, covered eresources, etc. Now, those accordion's headers show the count of items in that accordion.