### PR TITLE
Erm 35

### DIFF
--- a/src/components/Agreements/AgreementFilters/AgreementFilters.js
+++ b/src/components/Agreements/AgreementFilters/AgreementFilters.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, AccordionSet, FilterAccordionHeader } from '@folio/stripes/components';
+import { Accordion, AccordionSet, FilterAccordionHeader, Selection } from '@folio/stripes/components';
 import { CheckboxFilter } from '@folio/stripes/smart-components';
 import { OrganizationSelection } from '@folio/stripes-erm-components';
 
@@ -96,6 +96,27 @@ export default class AgreementFilters extends React.Component {
     );
   }
 
+  renderRoleLabel = () => {
+    const roles = get(this.props.resources.orgRoleValues, ['records'], []);
+    const dataOptions = roles.map(role => ({
+      value: role.id,
+      label: role.label,
+    }));
+
+    const orgFilters = this.props.activeFilters.orgs || [];
+    const activeFilters = this.props.activeFilters.role || [];
+
+    return (
+      <Selection
+        dataOptions={dataOptions}
+        label="Organization Role"
+        disabled={orgFilters.length === 0}
+        value={activeFilters[0] || ''}
+        onChange={value => this.props.onChange({ name: 'role', values: [value] })}
+      />
+    );
+  }
+
   render() {
     return (
       <AccordionSet>
@@ -103,6 +124,7 @@ export default class AgreementFilters extends React.Component {
         {this.renderCheckboxFilter('renewalPriority', { closedByDefault: true })}
         {this.renderCheckboxFilter('isPerpetual', { closedByDefault: true })}
         {this.renderOrganizationFilter()}
+        {this.renderRoleLabel()}
       </AccordionSet>
     );
   }

--- a/src/components/Agreements/AgreementFilters/AgreementFilters.js
+++ b/src/components/Agreements/AgreementFilters/AgreementFilters.js
@@ -83,7 +83,10 @@ export default class AgreementFilters extends React.Component {
         displayClearButton={activeFilters.length > 0}
         header={FilterAccordionHeader}
         label={<FormattedMessage id="ui-agreements.agreements.organizations" />}
-        onClearFilter={() => { this.props.onChange({ name: 'orgs', values: [] }); }}
+        onClearFilter={() => {
+          this.props.onChange({ name: 'orgs', values: [] });
+          this.props.onChange({ name: 'role', values: [] });
+        }}
       >
         <OrganizationSelection
           input={{
@@ -107,13 +110,20 @@ export default class AgreementFilters extends React.Component {
     const activeFilters = this.props.activeFilters.role || [];
 
     return (
-      <Selection
-        dataOptions={dataOptions}
-        label="Organization Role"
-        disabled={orgFilters.length === 0}
-        value={activeFilters[0] || ''}
-        onChange={value => this.props.onChange({ name: 'role', values: [value] })}
-      />
+      <Accordion
+        closedByDefault
+        displayClearButton={activeFilters.length > 0}
+        header={FilterAccordionHeader}
+        label={<FormattedMessage id="ui-agreements.settings.orgRoles.orgRole" />}
+        onClearFilter={() => { this.props.onChange({ name: 'role', values: [] }); }}
+      >
+        <Selection
+          dataOptions={dataOptions}
+          disabled={orgFilters.length === 0}
+          value={activeFilters[0] || ''}
+          onChange={value => this.props.onChange({ name: 'role', values: [value] })}
+        />
+      </Accordion>
     );
   }
 

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -34,6 +34,7 @@ class Agreements extends React.Component {
         },
         filterKeys: {
           orgs: 'orgs.org',
+          role: 'orgs.role',
         },
       }),
     },


### PR DESCRIPTION
(1) "Filter by Organisation-Role does not change default Agreement Search filters":
the preset status filters are deleted when an organisation is selected, if manually set the other filters remain
(2) "pre-definded roles":
is this a backend issue? vendor role is still not present and more roles than the pre-defined are shown