### PR TITLE
ERM-30: Don't throw errors from orders-storage endpoint

### DIFF
--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -71,6 +71,7 @@ class ViewAgreement extends React.Component {
       },
       records: 'po_lines',
       shouldRefresh,
+      throwErrors: false,
     },
     agreementEresources: {
       type: 'okapi',


### PR DESCRIPTION
We should come up with a longer-term solution than this but as-is `ui-agreements` is broken if run on a platform without whatever module implements the `orders-storage` endpoint.