### PR TITLE
ERM-63: Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "stripes serve",
     "build": "stripes build --output ./output",
-    "test": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses/linked-licenses",
+    "test": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses",
     "test-nav": "stripes test nightmare --run nav",
     "test-agreement-crud": "stripes test nightmare --run agreement-crud",
     "test-basket": "stripes test nightmare --run basket",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@folio/stripes-erm-components": "^1.0.6",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0",
     "react-router-dom": "^4.1.1",

--- a/test/ui-testing/agreement-crud.js
+++ b/test/ui-testing/agreement-crud.js
@@ -45,6 +45,12 @@ const createAgreement = (nightmare, done, defaultValues, resourceId) => {
 
     .click('#clickable-createagreement')
     .wait('#agreementInfo')
+    .wait(agreementName => {
+      const nameElement = document.querySelector('[data-test-agreement-name]');
+      if (!nameElement) return false;
+
+      return nameElement.innerText === agreementName;
+    }, values.name)
     .evaluate(expectedValues => {
       const foundName = document.querySelector('[data-test-agreement-name]').innerText;
       if (foundName !== expectedValues.name) {

--- a/test/ui-testing/linked-licenses.js
+++ b/test/ui-testing/linked-licenses.js
@@ -216,6 +216,53 @@ module.exports.test = (uiTestCtx) => {
             .catch(done);
         });
       }
+
+      it('should open Licenses module', done => {
+        nightmare
+          .wait('#app-list-item-clickable-licenses-module')
+          .click('#app-list-item-clickable-licenses-module')
+          .wait('#licenses-module-display')
+          .exists('#app-list-dropdown-toggle[aria-expanded="true"]')
+          .then(dropdownOpen => {
+            if (dropdownOpen) nightmare.click('#app-list-dropdown-toggle');
+          })
+          .then(done)
+          .catch(done);
+      });
+
+      it(`should find and open ${licenses[0].name}`, done => {
+        nightmare
+          .wait('#input-license-search')
+          .insert('#input-license-search', licenses[0].name)
+          .click('#pane-filter button[type="submit"]')
+          .waitUntilNetworkIdle(2000)
+          .click('#list-licenses [aria-rowindex="2"] a')
+          .wait(licenseName => {
+            const nameElement = document.querySelector('[data-test-license-name]');
+            if (!nameElement) return false;
+
+            return nameElement.innerText === licenseName;
+          }, licenses[0].name)
+          .then(done)
+          .catch(done);
+      });
+
+      it(`should find ${agreement.name} in Linked Agreements section`, done => {
+        nightmare
+          .wait('#linked-agreements-table')
+          .evaluate(agreementName => {
+            const nameElement = document.evaluate(
+              `//*[@id="linked-agreements-table"]//div[.="${agreementName}"]`,
+              document,
+              null,
+              XPathResult.FIRST_ORDERED_NODE_TYPE
+            ).singleNodeValue;
+
+            if (!nameElement) throw Error(`Expected linked agreement node for name ${agreementName}`);
+          }, agreement.name)
+          .then(done)
+          .catch(done);
+      });
     });
   });
 };


### PR DESCRIPTION
- Augmented the `linked-licenses` test to check that the linkage is visible in the Licenses module.
- Removed the `linked-licenses` test from the default run because it requires the Licenses module as well as the Agreements module. It'll be added as an integration test of `platform-erm`.
- Updated our dependency on lodash due to security errors.