### PR TITLE
UIER-34: Display "show invoices" link

### DIFF
--- a/src/components/Agreements/ViewAgreement/Sections/Finances.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Finances.js
@@ -10,6 +10,7 @@ export default class Finances extends React.Component {
   static propTypes = {
     financesAgreementLines: PropTypes.arrayOf(PropTypes.object),
     id: PropTypes.string,
+    invoices: PropTypes.arrayOf(PropTypes.object),
     onToggle: PropTypes.func,
     open: PropTypes.bool,
   };
@@ -20,6 +21,14 @@ export default class Finances extends React.Component {
       return <Icon icon="spinner-ellipsis" width="10px" />;
     }
     return <Badge data-test-finances-agreement-lines-count={count}>{count}</Badge>;
+  }
+
+  renderInvoices = () => {
+    const invoices = get(this.props, 'invoices', []);
+    if (!invoices.length) {
+      return null;
+    }
+    return <div align="end"><FormattedMessage id="ui-agreements.agreements.showInvoicesLink" /></div>;
   }
 
   render() {
@@ -45,6 +54,7 @@ export default class Finances extends React.Component {
         displayWhenClosed={buttonAndBadge}
         displayWhenOpen={buttonAndBadge}
       >
+        {this.renderInvoices()}
         <FinancesAgreementLines
           visible={open}
           {...this.props}

--- a/src/components/Agreements/ViewAgreement/Sections/Finances.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Finances.js
@@ -28,7 +28,7 @@ export default class Finances extends React.Component {
     if (!invoices.length) {
       return null;
     }
-    return <Layout align="end"><FormattedMessage id="ui-agreements.agreements.showInvoicesLink" /></Layout>;
+    return <Layout class="textRight"><FormattedMessage id="ui-agreements.agreements.showInvoicesLink" /></Layout>;
   }
 
   render() {

--- a/src/components/Agreements/ViewAgreement/Sections/Finances.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Finances.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Accordion, Badge, Button, Icon } from '@folio/stripes/components';
+import { Accordion, Badge, Button, Icon, Layout } from '@folio/stripes/components';
 
 import FinancesAgreementLines from './FinancesAgreementLines';
 
@@ -28,7 +28,7 @@ export default class Finances extends React.Component {
     if (!invoices.length) {
       return null;
     }
-    return <div align="end"><FormattedMessage id="ui-agreements.agreements.showInvoicesLink" /></div>;
+    return <Layout align="end"><FormattedMessage id="ui-agreements.agreements.showInvoicesLink" /></Layout>;
   }
 
   render() {

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -139,11 +139,15 @@ class ViewAgreement extends React.Component {
   componentDidUpdate(prevProps) {
     const prevUsers = get(prevProps.resources.contacts, ['records'], []).map(c => c.user);
     const users = get(this.props.resources.contacts, ['records'], []).map(c => c.user);
+    const prevFinances = get(prevProps.resources.financesAgreementLines, ['records'], []).map(f => f.id);
+    const finances = get(this.props.resources.financesAgreementLines, ['records'], []).map(f => f.id);
     const prevAgreement = get(prevProps.resources.selectedAgreement, ['records', 0], {});
     const agreement = get(this.props.resources.selectedAgreement, ['records', 0], {});
 
     if ((prevAgreement.id !== agreement.id) || (difference(users, prevUsers).length)) {
       this.fetchUsers();
+    }
+    if ((prevAgreement.id !== agreement.id) || (difference(finances, prevFinances).length)) {
       this.fetchInvoices();
     }
   }
@@ -267,6 +271,10 @@ class ViewAgreement extends React.Component {
   };
 
   fetchInvoices = () => {
+    if (!this.props.stripes.hasInterface('invoice-storage.invoice-line', '1.0')) {
+      return;
+    }
+
     const poLines = this.getFinancesAgreementLines();
     if (poLines === undefined) {
       return;

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -43,6 +43,7 @@
   "agreements.agreementLines": "Agreement lines",
   "agreements.financesAgreementLines": "Finances — agreement lines",
   "agreements.editFinancesAgreementLines": "Edit agreement lines",
+  "agreements.showInvoicesLink": "Show invoices",
   "agreements.financeReports": "Finance Reports",
   "agreements.license": "License",
   "agreements.licenseAndBusTerms": "License and business terms",


### PR DESCRIPTION
If there exists an invoice line where one of the poLineIds matches one of the poLineIds of the
current agreement then display the "Show invoices" link.

Endpoint to query: /invoice-storage/invoice-lines
https://github.com/folio-org/mod-invoice-storage/blob/master/ramls/invoice.raml
https://github.com/folio-org/acq-models/blob/master/mod-invoice-storage/schemas/invoice_line.json

The link label is shown but without a clickable link because the destination doesn't exist yet:
https://github.com/folio-org/ui-invoice