### PR TITLE
ERM-65/ERM-104/ERM-105/ERM-106/ERM-107: Custom Coverage for Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,12 @@
   "scripts": {
     "start": "stripes serve",
     "build": "stripes build --output ./output",
-    "test": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses",
+    "test": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses/custom-coverage",
     "test-nav": "stripes test nightmare --run nav",
     "test-agreement-crud": "stripes test nightmare --run agreement-crud",
     "test-basket": "stripes test nightmare --run basket",
     "test-external-licenses": "stripes test nightmare --run external-licenses",
+    "test-custom-coverage": "stripes test nightmare --run custom-coverage",
     "test-linked-licenses": "stripes test nightmare --run linked-licenses",
     "lint": "eslint src"
   },

--- a/src/components/Agreements/AgreementForm/components/AgreementLineField.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLineField.js
@@ -13,6 +13,7 @@ import {
 import BasketSelector from '../../../BasketSelector';
 import EResourceLink from '../../../EResourceLink';
 import ResourceType from '../../../ResourceType';
+import isPackage from '../../../../util/isPackage';
 
 import CustomCoverageFieldArray from './CustomCoverageFieldArray';
 import EditCard from './EditCard';
@@ -52,6 +53,10 @@ export default class AgreementLineField extends React.Component {
   }
 
   renderCustomCoverageSelector = () => {
+    const { resource } = this.props;
+
+    if (isPackage(resource)) return null;
+
     return (
       <FieldArray
         component={CustomCoverageFieldArray}

--- a/src/components/Agreements/AgreementForm/components/AgreementLineField.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLineField.js
@@ -20,6 +20,7 @@ import EditCard from './EditCard';
 export default class AgreementLineField extends React.Component {
   static propTypes = {
     index: PropTypes.number,
+    name: PropTypes.string.isRequired,
     onDelete: PropTypes.func,
     onResourceSelected: PropTypes.func,
     resource: PropTypes.object,
@@ -51,13 +52,10 @@ export default class AgreementLineField extends React.Component {
   }
 
   renderCustomCoverageSelector = () => {
-    const { resource } = this.props;
-
     return (
       <FieldArray
         component={CustomCoverageFieldArray}
-        name="coverage"
-        resource={resource}
+        name={`${this.props.name}.coverage`}
       />
     );
   }
@@ -89,7 +87,7 @@ export default class AgreementLineField extends React.Component {
             </KeyValue>
           </Col>
         </Row>
-        {/* {this.renderCustomCoverageSelector()} */}
+        {this.renderCustomCoverageSelector()}
       </React.Fragment>
     );
   }

--- a/src/components/Agreements/AgreementForm/components/AgreementLineField.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLineField.js
@@ -2,11 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
+import { FieldArray } from 'redux-form';
 
 import {
-  Button,
   Col,
-  Icon,
   KeyValue,
   Row,
 } from '@folio/stripes/components';
@@ -14,7 +13,9 @@ import {
 import BasketSelector from '../../../BasketSelector';
 import EResourceLink from '../../../EResourceLink';
 import ResourceType from '../../../ResourceType';
-import css from './AgreementLinesFieldArray.css';
+
+import CustomCoverageFieldArray from './CustomCoverageFieldArray';
+import EditCard from './EditCard';
 
 export default class AgreementLineField extends React.Component {
   static propTypes = {
@@ -49,6 +50,18 @@ export default class AgreementLineField extends React.Component {
     );
   }
 
+  renderCustomCoverageSelector = () => {
+    const { resource } = this.props;
+
+    return (
+      <FieldArray
+        component={CustomCoverageFieldArray}
+        name="coverage"
+        resource={resource}
+      />
+    );
+  }
+
   renderLineResource = () => {
     const { resource } = this.props;
 
@@ -76,13 +89,7 @@ export default class AgreementLineField extends React.Component {
             </KeyValue>
           </Col>
         </Row>
-        {/*
-        <Row>
-          <Col xs={12}>
-            [Add Custom Coverage Button]
-          </Col>
-        </Row>
-        */}
+        {/* {this.renderCustomCoverageSelector()} */}
       </React.Fragment>
     );
   }
@@ -100,36 +107,17 @@ export default class AgreementLineField extends React.Component {
     const { index, resource = {} } = this.props;
 
     return (
-      <li
-        className={css.agLineField}
+      <EditCard
         data-test-ag-line-number={index}
+        header={<FormattedMessage id="ui-agreements.agreementLines.lineTitle" values={{ number: index + 1 }} />}
+        onDelete={this.props.onDelete}
       >
-        <div>
-          <div className={css.agLineHeader} start="xs">
-            <div>
-              <strong>
-                <FormattedMessage id="ui-agreements.agreementLines.lineTitle" values={{ number: index + 1 }} />
-              </strong>
-            </div>
-            <div className={css.agLineHeaderActions}>
-              <Button
-                buttonStyle="link slim"
-                style={{ margin: 0, padding: 0 }}
-                onClick={this.props.onDelete}
-              >
-                <Icon icon="trash" />
-              </Button>
-            </div>
-          </div>
-          <div className={css.agLineBody}>
-            {
-              resource.id ?
-                this.renderLineResource() :
-                this.renderLineSelector()
-            }
-          </div>
-        </div>
-      </li>
+        {
+          resource.id ?
+            this.renderLineResource() :
+            this.renderLineSelector()
+        }
+      </EditCard>
     );
   }
 }

--- a/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
@@ -7,13 +7,14 @@ import {
   Layout,
 } from '@folio/stripes/components';
 
-import withKiwtFieldArray from '../../../withKiwtFieldArray';
 import AgreementLineField from './AgreementLineField';
+import withKiwtFieldArray from './withKiwtFieldArray';
 
 class AgreementLinesFieldArray extends React.Component {
   static propTypes = {
     agreementLines: PropTypes.arrayOf(PropTypes.object),
     items: PropTypes.arrayOf(PropTypes.object),
+    name: PropTypes.string.isRequired,
     onAddField: PropTypes.func.isRequired,
     onDeleteField: PropTypes.func.isRequired,
     onReplaceField: PropTypes.func.isRequired,
@@ -42,6 +43,10 @@ class AgreementLinesFieldArray extends React.Component {
     this.props.onReplaceField(index, { resource });
   }
 
+  handleAddLine = () => {
+    this.props.onAddField({});
+  }
+
   renderEmpty = () => (
     <Layout className="padding-bottom-gutter">
       <FormattedMessage id="ui-agreements.agreementLines.noLines" />
@@ -54,6 +59,7 @@ class AgreementLinesFieldArray extends React.Component {
         key={i}
         index={i}
         line={line}
+        name={`${this.props.name}[${i}]`}
         onDelete={() => this.props.onDeleteField(i, line)}
         onResourceSelected={this.handleResourceSelected}
         resource={this.getLineResource(line)}
@@ -67,7 +73,7 @@ class AgreementLinesFieldArray extends React.Component {
         <div id="agreement-form-lines">
           { this.props.items.length ? this.renderLines() : this.renderEmpty() }
         </div>
-        <Button id="add-agreement-line-button" onClick={this.props.onAddField}>
+        <Button id="add-agreement-line-button" onClick={this.handleAddLine}>
           <FormattedMessage id="ui-agreements.agreementLines.addLine" />
         </Button>
       </div>

--- a/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
@@ -7,13 +7,16 @@ import {
   Layout,
 } from '@folio/stripes/components';
 
+import withKiwtFieldArray from '../../../withKiwtFieldArray';
 import AgreementLineField from './AgreementLineField';
-import css from './AgreementLinesFieldArray.css';
 
-export default class AgreementLinesFieldArray extends React.Component {
+class AgreementLinesFieldArray extends React.Component {
   static propTypes = {
     agreementLines: PropTypes.arrayOf(PropTypes.object),
-    fields: PropTypes.object,
+    items: PropTypes.arrayOf(PropTypes.object),
+    onAddField: PropTypes.func.isRequired,
+    onDeleteField: PropTypes.func.isRequired,
+    onReplaceField: PropTypes.func.isRequired,
     parentResources: PropTypes.object,
   }
 
@@ -36,18 +39,7 @@ export default class AgreementLinesFieldArray extends React.Component {
   }
 
   handleResourceSelected = (index, resource) => {
-    this.props.fields.remove(index);
-    this.props.fields.insert(index, { resource });
-  }
-
-  handleDeleteLine = (index, line) => {
-    const { fields } = this.props;
-
-    fields.remove(index);
-
-    if (line.id) {
-      fields.push({ id: line.id, _delete: true });
-    }
+    this.props.onReplaceField(index, { resource });
   }
 
   renderEmpty = () => (
@@ -56,13 +48,13 @@ export default class AgreementLinesFieldArray extends React.Component {
     </Layout>
   )
 
-  renderLines = (lines) => {
-    return lines.map((line, i) => (
+  renderLines = () => {
+    return this.props.items.map((line, i) => (
       <AgreementLineField
         key={i}
         index={i}
         line={line}
-        onDelete={() => this.handleDeleteLine(i, line)}
+        onDelete={() => this.props.onDeleteField(i, line)}
         onResourceSelected={this.handleResourceSelected}
         resource={this.getLineResource(line)}
       />
@@ -70,20 +62,17 @@ export default class AgreementLinesFieldArray extends React.Component {
   }
 
   render = () => {
-    const { fields } = this.props;
-
-    // Get the agreement lines and filter away lines that have been marked for deletion.
-    const lines = (fields.getAll() || []).filter(line => !line._delete);
-
     return (
       <div>
-        <ul id="agreement-form-lines" className={css.agLineFieldArray}>
-          { lines.length ? this.renderLines(lines) : this.renderEmpty() }
-        </ul>
-        <Button id="add-agreement-line-button" onClick={() => fields.push({})}>
+        <div id="agreement-form-lines">
+          { this.props.items.length ? this.renderLines() : this.renderEmpty() }
+        </div>
+        <Button id="add-agreement-line-button" onClick={this.props.onAddField}>
           <FormattedMessage id="ui-agreements.agreementLines.addLine" />
         </Button>
       </div>
     );
   }
 }
+
+export default withKiwtFieldArray(AgreementLinesFieldArray);

--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -76,6 +76,7 @@ class CustomCoverageFieldArray extends React.Component {
                 backendDateStandard="YYYY-MM-DD"
                 dateFormat="YYYY-MM-DD"
                 component={Datepicker}
+                id={`cc-start-date-${index}`}
                 label="Start date"
                 name={`${name}[${index}].startDate`}
                 required
@@ -85,6 +86,7 @@ class CustomCoverageFieldArray extends React.Component {
             <Col xs={4}>
               <Field
                 component={TextField}
+                id={`cc-start-volume-${index}`}
                 label="Start volume"
                 name={`${name}[${index}].startVolume`}
               />
@@ -92,6 +94,7 @@ class CustomCoverageFieldArray extends React.Component {
             <Col xs={4}>
               <Field
                 component={TextField}
+                id={`cc-start-issue-${index}`}
                 label="Start issue"
                 name={`${name}[${index}].startIssue`}
               />
@@ -103,6 +106,7 @@ class CustomCoverageFieldArray extends React.Component {
                 backendDateStandard="YYYY-MM-DD"
                 dateFormat="YYYY-MM-DD"
                 component={Datepicker}
+                id={`cc-end-date-${index}`}
                 label="End date"
                 name={`${name}[${index}].endDate`}
                 validate={this.validateDateOrder}
@@ -111,6 +115,7 @@ class CustomCoverageFieldArray extends React.Component {
             <Col xs={4}>
               <Field
                 component={TextField}
+                id={`cc-end-volume-${index}`}
                 label="End volume"
                 name={`${name}[${index}].endVolume`}
               />
@@ -118,6 +123,7 @@ class CustomCoverageFieldArray extends React.Component {
             <Col xs={4}>
               <Field
                 component={TextField}
+                id={`cc-end-issue-${index}`}
                 label="End issue"
                 name={`${name}[${index}].endIssue`}
               />

--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Button,
+} from '@folio/stripes/components';
+
+import withKiwtFieldArray from '../../../withKiwtFieldArray';
+
+class CustomCoverageFieldArray extends React.Component {
+  static propTypes = {
+    items: PropTypes.arrayOf(PropTypes.object),
+    resource: PropTypes.object,
+  }
+
+  static defaultProps = {
+    items: [],
+  }
+
+  renderLines = () => {
+    return 'Custom Coverage List';
+  }
+
+  render = () => {
+    return (
+      <div>
+        <div id="agreement-form-custom-coverages">
+          { this.renderCustomCoverages() }
+        </div>
+        <Button id="add-agreement-custom-coverage-button" onClick={this.onAddField}>
+          <FormattedMessage id="ui-agreements.agreementLines.addCustomCoverage" />
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default withKiwtFieldArray(CustomCoverageFieldArray);

--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'redux-form';
 
@@ -13,6 +14,7 @@ import {
 
 import EditCard from './EditCard';
 import withKiwtFieldArray from './withKiwtFieldArray';
+import { required } from '../../../../util/validators';
 
 class CustomCoverageFieldArray extends React.Component {
   static propTypes = {
@@ -24,6 +26,33 @@ class CustomCoverageFieldArray extends React.Component {
 
   static defaultProps = {
     items: [],
+  }
+
+  validateDateOrder = (value, allValues, _props, name) => {
+    if (value) {
+      let startDate;
+      let endDate;
+
+      if (name.indexOf('startDate') >= 0) {
+        startDate = new Date(value);
+        endDate = new Date(get(allValues, name.replace('startDate', 'endDate')));
+      } else if (name.indexOf('endDate') >= 0) {
+        startDate = new Date(get(allValues, name.replace('endDate', 'startDate')));
+        endDate = new Date(value);
+      } else {
+        return undefined;
+      }
+
+      if (startDate >= endDate) {
+        return (
+          <div data-test-error-end-date-too-early>
+            <FormattedMessage id="ui-agreements.errors.endDateGreaterThanStartDate" />
+          </div>
+        );
+      }
+    }
+
+    return undefined;
   }
 
   handleAddCustomCoverage = () => {
@@ -49,6 +78,8 @@ class CustomCoverageFieldArray extends React.Component {
                 component={Datepicker}
                 label="Start date"
                 name={`${name}[${index}].startDate`}
+                required
+                validate={[required, this.validateDateOrder]}
               />
             </Col>
             <Col xs={4}>
@@ -74,6 +105,7 @@ class CustomCoverageFieldArray extends React.Component {
                 component={Datepicker}
                 label="End date"
                 name={`${name}[${index}].endDate`}
+                validate={this.validateDateOrder}
               />
             </Col>
             <Col xs={4}>

--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -1,25 +1,99 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { Field } from 'redux-form';
 
 import {
   Button,
+  Col,
+  Datepicker,
+  Row,
+  TextField,
 } from '@folio/stripes/components';
 
-import withKiwtFieldArray from '../../../withKiwtFieldArray';
+import EditCard from './EditCard';
+import withKiwtFieldArray from './withKiwtFieldArray';
 
 class CustomCoverageFieldArray extends React.Component {
   static propTypes = {
     items: PropTypes.arrayOf(PropTypes.object),
-    resource: PropTypes.object,
+    name: PropTypes.string.isRequired,
+    onAddField: PropTypes.func.isRequired,
+    onDeleteField: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     items: [],
   }
 
-  renderLines = () => {
-    return 'Custom Coverage List';
+  handleAddCustomCoverage = () => {
+    this.props.onAddField({});
+  }
+
+  renderCustomCoverages = () => {
+    const { items, name } = this.props;
+
+    return items.map((coverage, index) => (
+      <EditCard
+        data-test-cc-number={index}
+        header={<FormattedMessage id="ui-agreements.agreementLines.customCoverageTitle" values={{ number: index + 1 }} />}
+        key={index}
+        onDelete={() => this.props.onDeleteField(index, coverage)}
+      >
+        <div>
+          <Row>
+            <Col xs={4}>
+              <Field
+                backendDateStandard="YYYY-MM-DD"
+                dateFormat="YYYY-MM-DD"
+                component={Datepicker}
+                label="Start date"
+                name={`${name}[${index}].startDate`}
+              />
+            </Col>
+            <Col xs={4}>
+              <Field
+                component={TextField}
+                label="Start volume"
+                name={`${name}[${index}].startVolume`}
+              />
+            </Col>
+            <Col xs={4}>
+              <Field
+                component={TextField}
+                label="Start issue"
+                name={`${name}[${index}].startIssue`}
+              />
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={4}>
+              <Field
+                backendDateStandard="YYYY-MM-DD"
+                dateFormat="YYYY-MM-DD"
+                component={Datepicker}
+                label="End date"
+                name={`${name}[${index}].endDate`}
+              />
+            </Col>
+            <Col xs={4}>
+              <Field
+                component={TextField}
+                label="End volume"
+                name={`${name}[${index}].endVolume`}
+              />
+            </Col>
+            <Col xs={4}>
+              <Field
+                component={TextField}
+                label="End issue"
+                name={`${name}[${index}].endIssue`}
+              />
+            </Col>
+          </Row>
+        </div>
+      </EditCard>
+    ));
   }
 
   render = () => {
@@ -28,7 +102,7 @@ class CustomCoverageFieldArray extends React.Component {
         <div id="agreement-form-custom-coverages">
           { this.renderCustomCoverages() }
         </div>
-        <Button id="add-agreement-custom-coverage-button" onClick={this.onAddField}>
+        <Button id="add-agreement-custom-coverage-button" onClick={this.handleAddCustomCoverage}>
           <FormattedMessage id="ui-agreements.agreementLines.addCustomCoverage" />
         </Button>
       </div>

--- a/src/components/Agreements/AgreementForm/components/EditCard.css
+++ b/src/components/Agreements/AgreementForm/components/EditCard.css
@@ -1,10 +1,6 @@
 @import '@folio/stripes-components/lib/variables';
 
-.agLineFieldArray {
-  list-style: none;
-  padding: 0;
-}
-.agLineField {
+.card {
   width: 100%;
   border-color: var(--color-border-p2);
   border-width: 1px 1px 0;
@@ -16,7 +12,7 @@
   }
 }
 
-.agLineHeader {
+.header {
   background-color: var(--bg-hover);
   display: flex;
   justify-content: flex-start;
@@ -24,12 +20,12 @@
   padding: 0 14px;
 }
 
-.agLineHeaderActions {
+.headerDelete {
   margin: 0 0 0 auto; /* align to end of header */
   padding: 4px 0;
 }
 
-.agLineBody {
+.body {
   padding: 14px;
   background-color: color(var(--bg) blend(var(--bg-hover) 20%));
   width: 100%;

--- a/src/components/Agreements/AgreementForm/components/EditCard.js
+++ b/src/components/Agreements/AgreementForm/components/EditCard.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Button,
+  Icon,
+} from '@folio/stripes/components';
+
+import css from './EditCard.css';
+
+export default class extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    header: PropTypes.node.isRequired,
+    onDelete: PropTypes.func,
+  }
+
+  renderDeleteButton = () => (
+    <Button
+      buttonStyle="link slim"
+      style={{ margin: 0, padding: 0 }}
+      onClick={this.props.onDelete}
+    >
+      <Icon icon="trash" />
+    </Button>
+  )
+
+  render() {
+    const {
+      children,
+      header,
+      onDelete,
+      ...rest
+    } = this.props;
+
+    return (
+      <div
+        className={css.card}
+        {...rest}
+      >
+        <div>
+          <div className={css.header} start="xs">
+            <div>
+              <strong>{ header }</strong>
+            </div>
+            <div className={css.headerDelete}>
+              { onDelete ? this.renderDeleteButton() : null }
+            </div>
+          </div>
+          <div className={css.body}>
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/Agreements/AgreementForm/components/EditCard.js
+++ b/src/components/Agreements/AgreementForm/components/EditCard.js
@@ -8,7 +8,7 @@ import {
 
 import css from './EditCard.css';
 
-export default class extends React.PureComponent {
+export default class extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     header: PropTypes.node.isRequired,

--- a/src/components/Agreements/AgreementForm/components/withKiwtFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/withKiwtFieldArray.js
@@ -40,6 +40,7 @@ export default function withKiwtFieldArray(WrappedComponent) {
         <WrappedComponent
           {...this.props}
           items={items}
+          name={fields.name}
           onAddField={this.handleAddField}
           onDeleteField={this.handleDeleteField}
           onReplaceField={this.handleReplaceField}

--- a/src/components/Agreements/AgreementForm/components/withKiwtFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/withKiwtFieldArray.js
@@ -8,7 +8,13 @@ const getDisplayName = (WrappedComponent) => {
 export default function withKiwtFieldArray(WrappedComponent) {
   class WithKiwtFieldArray extends React.Component {
     static propTypes = {
-      fields: PropTypes.object,
+      fields: PropTypes.shape({
+        getAll: PropTypes.func.isRequired,
+        insert: PropTypes.func.isRequired,
+        name: PropTypes.string.isRequired,
+        push: PropTypes.func.isRequired,
+        remove: PropTypes.func.isRequired,
+      }).isRequired,
     }
 
     handleAddField = (field = {}) => {

--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -53,8 +53,8 @@ export default class EresourceAgreementLines extends React.Component {
     type: line => <ResourceType resource={line.resource} />,
     count: line => (get(line, ['_object', 'contentItems'], [0])).length, // If contentItems doesn't exist there's only one item.
     contentUpdated: ({ contentUpdated }) => (contentUpdated ? <FormattedDate value={contentUpdated} /> : '-'),
-    coverage: line => <CoverageStatements isCustomCoverage={line.customCoverage} statements={line.coverage} />,
-    isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : null),
+    coverage: line => <CoverageStatements statements={line.coverage} />,
+    isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : ''),
   }
 
   visibleColumns = [

--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
-import { MultiColumnList } from '@folio/stripes/components';
+import { Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 
 import EResourceLink from '../../../EResourceLink';
 import ResourceType from '../../../ResourceType';
+import CoverageStatements from '../../../CoverageStatements';
 
 export default class EresourceAgreementLines extends React.Component {
   static propTypes = {
@@ -14,9 +15,11 @@ export default class EresourceAgreementLines extends React.Component {
   };
 
   columnWidths = {
-    name: '20%',
-    platform: '20%',
-    type: '10%',
+    name: 250,
+    platform: 150,
+    type: 100,
+    coverage: 225,
+    isCustomCoverage: 25,
   }
 
   columnMapping = {
@@ -25,6 +28,8 @@ export default class EresourceAgreementLines extends React.Component {
     type: <FormattedMessage id="ui-agreements.eresources.erType" />,
     count: <FormattedMessage id="ui-agreements.agreementLines.count" />,
     contentUpdated: <FormattedMessage id="ui-agreements.agreementLines.contentUpdated" />,
+    coverage: <FormattedMessage id="ui-agreements.eresources.coverage" />,
+    isCustomCoverage: ' ',
   }
 
   formatter = {
@@ -47,6 +52,8 @@ export default class EresourceAgreementLines extends React.Component {
     type: line => <ResourceType resource={line.resource} />,
     count: line => (get(line, ['_object', 'contentItems'], [0])).length, // If contentItems doesn't exist there's only one item.
     contentUpdated: ({ contentUpdated }) => (contentUpdated ? <FormattedDate value={contentUpdated} /> : '-'),
+    coverage: line => <CoverageStatements isCustomCoverage={line.customCoverage} statements={line.coverage} />,
+    isCustomCoverage: e => (e.customCoverage ? <Layout className="flex"><Icon icon="clock" status="success" /></Layout> : null),
   }
 
   visibleColumns = [
@@ -55,6 +62,8 @@ export default class EresourceAgreementLines extends React.Component {
     'type',
     'count',
     'contentUpdated',
+    'coverage',
+    'isCustomCoverage',
   ]
 
   render() {

--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -7,6 +7,7 @@ import { Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 import EResourceLink from '../../../EResourceLink';
 import ResourceType from '../../../ResourceType';
 import CoverageStatements from '../../../CoverageStatements';
+import CustomCoverageIcon from '../../../CustomCoverageIcon';
 
 export default class EresourceAgreementLines extends React.Component {
   static propTypes = {
@@ -53,7 +54,7 @@ export default class EresourceAgreementLines extends React.Component {
     count: line => (get(line, ['_object', 'contentItems'], [0])).length, // If contentItems doesn't exist there's only one item.
     contentUpdated: ({ contentUpdated }) => (contentUpdated ? <FormattedDate value={contentUpdated} /> : '-'),
     coverage: line => <CoverageStatements isCustomCoverage={line.customCoverage} statements={line.coverage} />,
-    isCustomCoverage: e => (e.customCoverage ? <Layout className="flex"><Icon icon="clock" status="success" /></Layout> : null),
+    isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : null),
   }
 
   visibleColumns = [
@@ -65,6 +66,17 @@ export default class EresourceAgreementLines extends React.Component {
     'coverage',
     'isCustomCoverage',
   ]
+
+  renderCustomCoverage = () => {
+    return (
+      <Layout
+        className="flex"
+        data-test-custom-coverage
+      >
+        <Icon icon="clock" status="success" />
+      </Layout>
+    );
+  }
 
   render() {
     return (

--- a/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
@@ -50,8 +50,8 @@ export default class EresourcesCovered extends React.Component {
     haveAccess: () => 'TBD',
     accessStart: () => 'TBD',
     accessEnd: () => 'TBD',
-    coverage: e => <CoverageStatements isCustomCoverage={e.customCoverage} statements={e.coverage} />,
-    isCustomCoverage: e => (e.customCoverage ? <CustomCoverageIcon /> : null),
+    coverage: e => <CoverageStatements statements={e.coverage} />,
+    isCustomCoverage: e => (e.customCoverage ? <CustomCoverageIcon /> : ''),
   }
 
   visibleColumns = [

--- a/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import { Accordion, Badge, Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 
 import CoverageStatements from '../../../CoverageStatements';
+import CustomCoverageIcon from '../../../CustomCoverageIcon';
 import EResourceLink from '../../../EResourceLink';
 
 export default class EresourcesCovered extends React.Component {
@@ -50,7 +51,7 @@ export default class EresourcesCovered extends React.Component {
     accessStart: () => 'TBD',
     accessEnd: () => 'TBD',
     coverage: e => <CoverageStatements isCustomCoverage={e.customCoverage} statements={e.coverage} />,
-    isCustomCoverage: e => (e.customCoverage ? <Layout className="flex"><Icon icon="clock" status="success" /></Layout> : null),
+    isCustomCoverage: e => (e.customCoverage ? <CustomCoverageIcon /> : null),
   }
 
   visibleColumns = [
@@ -68,6 +69,17 @@ export default class EresourcesCovered extends React.Component {
     this.setState((prevState) => ({
       open: !prevState.open,
     }));
+  }
+
+  renderCustomCoverage = () => {
+    return (
+      <Layout
+        className="flex"
+        data-test-custom-coverage
+      >
+        <Icon icon="clock" status="success" />
+      </Layout>
+    );
   }
 
   renderBadge = () => {

--- a/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourcesCovered.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Accordion, Badge, Icon, MultiColumnList } from '@folio/stripes/components';
+import { Accordion, Badge, Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 
 import CoverageStatements from '../../../CoverageStatements';
 import EResourceLink from '../../../EResourceLink';
@@ -28,6 +28,15 @@ export default class EresourcesCovered extends React.Component {
     accessStart: <FormattedMessage id="ui-agreements.eresources.accessStart" />,
     accessEnd: <FormattedMessage id="ui-agreements.eresources.accessEnd" />,
     coverage: <FormattedMessage id="ui-agreements.eresources.coverage" />,
+    isCustomCoverage: ' ',
+  }
+
+  columnWidths = {
+    name: 250,
+    platform: 150,
+    package: 150,
+    coverage: 225,
+    isCustomCoverage: 25,
   }
 
   formatter = {
@@ -40,7 +49,8 @@ export default class EresourcesCovered extends React.Component {
     haveAccess: () => 'TBD',
     accessStart: () => 'TBD',
     accessEnd: () => 'TBD',
-    coverage: e => <CoverageStatements statements={e._object.coverageStatements} />,
+    coverage: e => <CoverageStatements isCustomCoverage={e.customCoverage} statements={e.coverage} />,
+    isCustomCoverage: e => (e.customCoverage ? <Layout className="flex"><Icon icon="clock" status="success" /></Layout> : null),
   }
 
   visibleColumns = [
@@ -51,6 +61,7 @@ export default class EresourcesCovered extends React.Component {
     'accessStart',
     'accessEnd',
     'coverage',
+    'isCustomCoverage'
   ]
 
   onToggleAccordion = () => {
@@ -78,6 +89,7 @@ export default class EresourcesCovered extends React.Component {
       >
         <MultiColumnList
           columnMapping={this.columnMapping}
+          columnWidths={this.columnWidths}
           contentData={this.props.visible && this.state.open ? agreementEresources : []}
           formatter={this.formatter}
           height={800}

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -230,7 +230,7 @@ class ViewAgreement extends React.Component {
 
           return {
             id: foundLine.id,
-            coverage: foundLine.coverage,
+            coverage: foundLine.customCoverage ? foundLine.coverage : undefined,
           };
         }
       });

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -180,42 +180,60 @@ class ViewAgreement extends React.Component {
   getInitialValues() {
     const agreement = cloneDeep(this.getAgreement());
     const {
-      agreementStatus,
-      renewalPriority,
-      isPerpetual,
-      contacts,
-      orgs,
-      linkedLicenses
+      agreementStatus = {},
+      renewalPriority = {},
+      isPerpetual = {},
+      contacts = [],
+      orgs = [],
+      linkedLicenses = [],
+      items = [],
     } = agreement;
 
-    if (agreementStatus && agreementStatus.id) {
+    if (agreementStatus.id) {
       agreement.agreementStatus = agreementStatus.id;
     }
 
-    if (renewalPriority && renewalPriority.id) {
+    if (renewalPriority.id) {
       agreement.renewalPriority = renewalPriority.id;
     }
 
-    if (isPerpetual && isPerpetual.id) {
+    if (isPerpetual.id) {
       agreement.isPerpetual = isPerpetual.id;
     }
 
-    if (orgs && orgs.length) {
-      agreement.orgs = orgs.map(o => ({ ...o, role: o.role.id }));
-    }
-
-    if (contacts) {
+    if (contacts.length) {
       agreement.contacts = contacts.map(c => ({
         ...c,
         role: c.role ? c.role.id : undefined,
       }));
     }
 
-    if (linkedLicenses) {
+    if (orgs.length) {
+      agreement.orgs = orgs.map(o => ({ ...o, role: o.role.id }));
+    }
+
+    if (linkedLicenses.length) {
       agreement.linkedLicenses = linkedLicenses.map(l => ({
         ...l,
         status: l.status.id,
       }));
+    }
+
+    const agreementLines = this.getAgreementLines() || [];
+    if (items.length && agreementLines.length) {
+      agreement.items = items.map(item => {
+        if (item.resource) {
+          return item;
+        } else {
+          const foundLine = agreementLines.find(line => line.id === item.id);
+          if (!foundLine) return item;
+
+          return {
+            id: foundLine.id,
+            coverage: foundLine.coverage,
+          };
+        }
+      });
     }
 
     return agreement;
@@ -270,7 +288,7 @@ class ViewAgreement extends React.Component {
     return (
       <Pane
         id="pane-view-agreement"
-        defaultWidth={this.props.paneWidth}
+        defaultWidth="60%"
         paneTitle="Loading..."
         dismissible
         onClose={this.props.onClose}
@@ -325,7 +343,7 @@ class ViewAgreement extends React.Component {
     return (
       <Pane
         id="pane-view-agreement"
-        defaultWidth={this.props.paneWidth}
+        defaultWidth="60%"
         paneTitle={agreement.name}
         dismissible
         onClose={this.props.onClose}

--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -45,12 +45,12 @@ export default class CoverageStatements extends React.Component {
 
     return (
       <React.Fragment>
-        { date ? <Layout className="textRight"><FormattedDate value={date} /></Layout> : null }
-        <Layout className="textRight">
+        { date ? <div><FormattedDate value={date} /></div> : null }
+        <div>
           {this.renderVolume(volume)}
           {volume && issue ? <React.Fragment>&nbsp;</React.Fragment> : null}
           {this.renderIssue(issue)}
-        </Layout>
+        </div>
       </React.Fragment>
     );
   }
@@ -58,7 +58,7 @@ export default class CoverageStatements extends React.Component {
   renderStatement = (statement, i) => {
     return (
       <Layout key={i} className="flex justified">
-        <Layout className="margin-end-gutter" style={{ width: '40%' }}>
+        <Layout className="margin-end-gutter textRight" style={{ width: '40%' }}>
           {this.renderDate(statement.startDate, statement.startVolume, statement.startIssue)}
         </Layout>
         <Icon icon="arrow-right" />

--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -45,8 +45,11 @@ export default class CoverageStatements extends React.Component {
 
     return (
       <React.Fragment>
-        { date ? <div><FormattedDate value={date} /></div> : null }
-        <div>
+        { date ? <div data-test-date={date}><FormattedDate value={date} /></div> : null }
+        <div
+          data-test-issue={issue}
+          data-test-volume={volume}
+        >
           {this.renderVolume(volume)}
           {volume && issue ? <React.Fragment>&nbsp;</React.Fragment> : null}
           {this.renderIssue(issue)}
@@ -57,12 +60,24 @@ export default class CoverageStatements extends React.Component {
 
   renderStatement = (statement, i) => {
     return (
-      <Layout key={i} className="flex justified">
-        <Layout className="margin-end-gutter textRight" style={{ width: '40%' }}>
+      <Layout
+        className="flex justified"
+        data-test-statement={i}
+        key={i}
+      >
+        <Layout
+          className="margin-end-gutter textRight"
+          data-test-start
+          style={{ width: '40%' }}
+        >
           {this.renderDate(statement.startDate, statement.startVolume, statement.startIssue)}
         </Layout>
         <Icon icon="arrow-right" />
-        <Layout className="margin-start-gutter" style={{ width: '40%' }}>
+        <Layout
+          className="margin-start-gutter"
+          data-test-end
+          style={{ width: '40%' }}
+        >
           {this.renderDate(statement.endDate, statement.endVolume, statement.endIssue)}
         </Layout>
       </Layout>
@@ -73,6 +88,6 @@ export default class CoverageStatements extends React.Component {
     const { statements } = this.props;
     if (!statements || !statements.length) return '-';
 
-    return <Layout className="full">{statements.map(this.renderStatement)}</Layout>;
+    return <Layout className="full" data-test-coverage-statements>{statements.map(this.renderStatement)}</Layout>;
   }
 }

--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -45,24 +45,24 @@ export default class CoverageStatements extends React.Component {
 
     return (
       <React.Fragment>
-        { date ? <div><FormattedDate value={date} /></div> : null }
-        <div>
+        { date ? <Layout className="textRight"><FormattedDate value={date} /></Layout> : null }
+        <Layout className="textRight">
           {this.renderVolume(volume)}
-          &nbsp;
+          {volume && issue ? <React.Fragment>&nbsp;</React.Fragment> : null}
           {this.renderIssue(issue)}
-        </div>
+        </Layout>
       </React.Fragment>
     );
   }
 
   renderStatement = (statement, i) => {
     return (
-      <Layout key={i} className="flex">
-        <Layout className="margin-end-gutter">
+      <Layout key={i} className="flex justified">
+        <Layout className="margin-end-gutter" style={{ width: '40%' }}>
           {this.renderDate(statement.startDate, statement.startVolume, statement.startIssue)}
         </Layout>
         <Icon icon="arrow-right" />
-        <Layout className="margin-start-gutter">
+        <Layout className="margin-start-gutter" style={{ width: '40%' }}>
           {this.renderDate(statement.endDate, statement.endVolume, statement.endIssue)}
         </Layout>
       </Layout>
@@ -73,6 +73,6 @@ export default class CoverageStatements extends React.Component {
     const { statements } = this.props;
     if (!statements || !statements.length) return '-';
 
-    return <div>{statements.map(this.renderStatement)}</div>;
+    return <Layout className="full">{statements.map(this.renderStatement)}</Layout>;
   }
 }

--- a/src/components/CustomCoverageIcon/CustomCoverageIcon.js
+++ b/src/components/CustomCoverageIcon/CustomCoverageIcon.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Icon, Layout } from '@folio/stripes/components';
+
+export default function CustomCoverage() {
+  return (
+    <Layout
+      className="flex"
+      data-test-custom-coverage
+    >
+      <Icon icon="clock" status="success" />
+    </Layout>
+  );
+}

--- a/src/components/CustomCoverageIcon/index.js
+++ b/src/components/CustomCoverageIcon/index.js
@@ -1,0 +1,1 @@
+export { default } from './CustomCoverageIcon';

--- a/src/components/EResources/EResourceAgreements/EResourceAgreements.js
+++ b/src/components/EResources/EResourceAgreements/EResourceAgreements.js
@@ -10,8 +10,8 @@ import {
 
 import EResourceLink from '../../EResourceLink';
 import ResourceType from '../../ResourceType';
-import CoverageStatements from '../../CoverageStatements'
-import CustomCoverageIcon from '../../CustomCoverageIcon'
+import CoverageStatements from '../../CoverageStatements';
+import CustomCoverageIcon from '../../CustomCoverageIcon';
 
 class EResourceAgreements extends React.Component {
   static manifest = Object.freeze({

--- a/src/components/EResources/EResourceAgreements/EResourceAgreements.js
+++ b/src/components/EResources/EResourceAgreements/EResourceAgreements.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import {
-  Col,
   Icon,
   MultiColumnList,
-  Row,
 } from '@folio/stripes/components';
 
 import EResourceLink from '../../EResourceLink';
 import ResourceType from '../../ResourceType';
+import CoverageStatements from '../../CoverageStatements'
+import CustomCoverageIcon from '../../CustomCoverageIcon'
 
 class EResourceAgreements extends React.Component {
   static manifest = Object.freeze({
@@ -38,7 +38,12 @@ class EResourceAgreements extends React.Component {
     'startDate',
     'endDate',
     ...(this.props.type === 'title' ?
-      ['package', 'acqMethod'] : []
+      [
+        'package',
+        'acqMethod',
+        'coverage',
+        'isCustomCoverage'
+      ] : []
     ),
   ]);
 
@@ -47,14 +52,10 @@ class EResourceAgreements extends React.Component {
     type: ({ owner }) => owner.agreementStatus && owner.agreementStatus.label,
     startDate: ({ owner }) => owner.startDate && <FormattedDate value={owner.startDate} />,
     endDate: ({ owner }) => owner.endDate && <FormattedDate value={owner.endDate} />,
-    ...(this.props.type === 'title' ?
-      {
-        package: ({ resource }) => <EResourceLink eresource={resource} />,
-        acqMethod: ({ resource }) => <ResourceType resource={resource} />,
-      }
-      :
-      {}
-    ),
+    package: ({ resource }) => <EResourceLink eresource={resource} />,
+    acqMethod: ({ resource }) => <ResourceType resource={resource} />,
+    coverage: line => <CoverageStatements statements={line.coverage} />,
+    isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : ''),
   });
 
   columnMapping = () => ({
@@ -62,14 +63,10 @@ class EResourceAgreements extends React.Component {
     type: <FormattedMessage id="ui-agreements.agreements.agreementStatus" />,
     startDate: <FormattedMessage id="ui-agreements.agreements.startDate" />,
     endDate: <FormattedMessage id="ui-agreements.agreements.endDate" />,
-    ...(this.props.type === 'title' ?
-      {
-        package: <FormattedMessage id="ui-agreements.eresources.parentPackage" />,
-        acqMethod: <FormattedMessage id="ui-agreements.eresources.acqMethod" />,
-      }
-      :
-      {}
-    ),
+    package: <FormattedMessage id="ui-agreements.eresources.parentPackage" />,
+    acqMethod: <FormattedMessage id="ui-agreements.eresources.acqMethod" />,
+    coverage: <FormattedMessage id="ui-agreements.eresources.coverage" />,
+    isCustomCoverage: ' ',
   });
 
   columnWidths = () => ({
@@ -80,24 +77,21 @@ class EResourceAgreements extends React.Component {
   render() {
     const { resources: { entitlements } } = this.props;
 
-    if (!entitlements || !entitlements.records) {
+    if (!entitlements || !entitlements.records || entitlements.isPending) {
       return <Icon icon="spinner-ellipsis" width="100px" />;
     }
 
     return (
-      <Row>
-        <Col xs={12}>
-          <MultiColumnList
-            contentData={entitlements.records}
-            interactive={false}
-            maxHeight={400}
-            columnMapping={this.columnMapping()}
-            columnWidths={this.columnWidths()}
-            formatter={this.formatter()}
-            visibleColumns={this.visibleColumns()}
-          />
-        </Col>
-      </Row>
+      <MultiColumnList
+        contentData={entitlements.records}
+        id="eresource-agreements-list"
+        interactive={false}
+        maxHeight={400}
+        columnMapping={this.columnMapping()}
+        columnWidths={this.columnWidths()}
+        formatter={this.formatter()}
+        visibleColumns={this.visibleColumns()}
+      />
     );
   }
 }

--- a/src/components/withKiwtFieldArray.js
+++ b/src/components/withKiwtFieldArray.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const getDisplayName = (WrappedComponent) => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+};
+
+export default function withKiwtFieldArray(WrappedComponent) {
+  class WithKiwtFieldArray extends React.Component {
+    static propTypes = {
+      fields: PropTypes.object,
+    }
+
+    handleAddField = (field = {}) => {
+      this.props.fields.push(field);
+    }
+
+    handleDeleteField = (index, field) => {
+      const { fields } = this.props;
+
+      fields.remove(index);
+
+      if (field.id) {
+        fields.push({ id: field.id, _delete: true });
+      }
+    }
+
+    handleReplaceField = (index, field) => {
+      this.props.fields.remove(index);
+      this.props.fields.insert(index, field);
+    }
+
+    render() {
+      const { fields } = this.props;
+
+      // Filter away items that have been marked for deletion.
+      const items = (fields.getAll() || []).filter(line => !line._delete);
+
+      return (
+        <WrappedComponent
+          {...this.props}
+          items={items}
+          onAddField={this.handleAddField}
+          onDeleteField={this.handleDeleteField}
+          onReplaceField={this.handleReplaceField}
+        />
+      );
+    }
+  }
+
+  WithKiwtFieldArray.displayName = `WithKiwtFieldArray(${getDisplayName(WrappedComponent)})`;
+  return WithKiwtFieldArray;
+}

--- a/test/ui-testing/agreement-crud.js
+++ b/test/ui-testing/agreement-crud.js
@@ -87,7 +87,7 @@ module.exports.generateAgreementValues = generateAgreementValues;
 module.exports.createAgreement = createAgreement;
 
 module.exports.test = (uiTestCtx) => {
-  describe('Module test: ui-agreements: basic agreement crud', function test() {
+  describe('ui-agreements: basic agreement crud', function test() {
     const { config, helpers: { login, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
     const values = generateAgreementValues();

--- a/test/ui-testing/basket.js
+++ b/test/ui-testing/basket.js
@@ -11,7 +11,7 @@ const _CONSTANTS = {
 
 const BASKET = [];
 
-const shouldAddTitleToBasket = (nightmare, index) => {
+const shouldAddTitleToBasket = (nightmare, index, basket = BASKET) => {
   it(`should add title ${index} to basket`, done => {
     nightmare
       .wait(`#list-agreements [aria-rowindex="${index + 1}"] a`)
@@ -34,14 +34,16 @@ const shouldAddTitleToBasket = (nightmare, index) => {
         return addedItem;
       }, index, _CONSTANTS)
       .then(addedItem => {
-        BASKET.push(addedItem);
+        basket.push(addedItem);
         done();
       })
       .catch(done);
   });
 };
 
-const shouldHaveCorrectAgreementLines = (nightmare, basketIndices = []) => {
+module.exports.shouldAddTitleToBasket = shouldAddTitleToBasket;
+
+const shouldHaveCorrectAgreementLines = (nightmare, basketIndices = [], basket = BASKET) => {
   it(`should see ${basketIndices.length} lines with correct resources`, done => {
     nightmare
       .wait('section#eresources')
@@ -73,7 +75,7 @@ const shouldHaveCorrectAgreementLines = (nightmare, basketIndices = []) => {
       })
       .then(lines => {
         basketIndices.forEach(index => {
-          const resource = BASKET[index];
+          const resource = basket[index];
           const line = lines.find(l => l.id === resource.id);
           if (!line) throw Error(`Could not find agreement line for ${resource.name}`);
           if (line.id !== resource.id) throw Error(`Expected Line #0 ID (${line.id}) to be ${resource.id}`);
@@ -86,9 +88,10 @@ const shouldHaveCorrectAgreementLines = (nightmare, basketIndices = []) => {
       .catch(done);
   });
 };
+module.exports.shouldHaveCorrectAgreementLines = shouldHaveCorrectAgreementLines;
 
 module.exports.test = (uiTestCtx) => {
-  describe('Module test: ui-agreements: basic basket functionality', function test() {
+  describe('ui-agreements: basic basket functionality', function test() {
     const { config, helpers: { login, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 

--- a/test/ui-testing/custom-coverage.js
+++ b/test/ui-testing/custom-coverage.js
@@ -1,0 +1,221 @@
+/* global describe, it, before, after, Nightmare */
+
+const AgreementCRUD = require('./agreement-crud');
+const Basket = require('./basket');
+const Utils = require('./utils');
+
+const checkTableForCustomCoverageIcon = (nightmare, done, tableId) => {
+  nightmare
+    .evaluate((id) => {
+      if (!document.querySelector(`#${id} [data-test-custom-coverage`)) {
+        throw Error(`Failed to find custom coverage icon in "${id}" table.`);
+      }
+    }, tableId)
+    .then(done)
+    .catch(done);
+};
+
+const checkTableForCustomCoverageData = (nightmare, done, tableId, values) => {
+  nightmare
+    .evaluate((expectedValues, id) => {
+      const startDates = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-start] [data-test-date]`)];
+      const startVolumes = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-start] [data-test-volume]`)];
+      const startIssues = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-start] [data-test-issue]`)];
+      const endDates = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-end] [data-test-date]`)];
+      const endVolumes = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-end] [data-test-volume]`)];
+      const endIssues = [...document.querySelectorAll(`#${id} [data-test-coverage-statements] [data-test-end] [data-test-issue]`)];
+
+      expectedValues.coverage.forEach(ec => {
+        if (!startDates.find(e => e.textContent !== ec.startDateFormatted)) {
+          throw Error(`Expected to find start date of ${ec.startDateFormatted} in #${id}`);
+        }
+        if (!startVolumes.find(e => e.textContent.indexOf(ec.startVolumeFormatted) !== -1)) {
+          throw Error(`Expected to find start volume of ${ec.startVolumeFormatted} in #${id}`);
+        }
+        if (!startIssues.find(e => e.textContent.indexOf(ec.startIssueFormatted) !== -1)) {
+          throw Error(`Expected to find start issue of ${ec.startIssueFormatted} in #${id}`);
+        }
+
+        if (!endDates.find(e => e.textContent !== ec.endDateFormatted)) {
+          throw Error(`Expected to find end date of ${ec.endDateFormatted} in #${id}`);
+        }
+        if (!endVolumes.find(e => e.textContent.indexOf(ec.endVolumeFormatted) !== -1)) {
+          throw Error(`Expected to find end volume of ${ec.endVolumeFormatted} in #${id}`);
+        }
+        if (!endIssues.find(e => e.textContent.indexOf(ec.endIssueFormatted) !== -1)) {
+          throw Error(`Expected to find end issue of ${ec.endIssueFormatted} in #${id}`);
+        }
+      });
+    }, values, tableId)
+    .then(done)
+    .catch(done);
+};
+
+module.exports.test = (uiTestCtx) => {
+  describe('ui-agreements: custom coverages', function test() {
+    const { config, helpers: { login, logout } } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
+    const values = {
+      name: `Custom Coverage Agreement #${Math.round(Math.random() * 100000)}`,
+      coverage: [
+        {
+          startDate: '2001-01-01',
+          startVolume: '1',
+          startIssue: '11',
+          endDate: '2010-12-31',
+          endVolume: '10',
+          endIssue: '12',
+        },
+        {
+          startDate: '2021-01-01',
+          startVolume: 'A',
+          startIssue: 'AA',
+          endDate: '2030-12-31',
+          endVolume: 'B',
+          endIssue: 'Z',
+        }
+      ]
+    };
+
+    values.coverage.forEach(c => {
+      c.startDateFormatted = Utils.formattedDate(c.startDate);
+      c.endDateFormatted = Utils.formattedDate(c.endDate);
+      c.startVolumeFormatted = `Vol:${c.startVolume}`;
+      c.endVolumeFormatted = `Vol:${c.endVolume}`;
+      c.startIssueFormatted = `Iss:${c.startIssue}`;
+      c.endIssueFormatted = `Iss:${c.endIssue}`;
+    });
+
+    const basket = [];
+
+    this.timeout(Number(config.test_timeout));
+
+    describe('login > fill basket > create agreement > set custom coverage > logout', () => {
+      before((done) => {
+        login(nightmare, config, done);
+      });
+
+      after((done) => {
+        logout(nightmare, config, done);
+      });
+
+      it('should open eresources', done => {
+        nightmare
+          .wait('#app-list-item-clickable-agreements-module')
+          .click('#app-list-item-clickable-agreements-module')
+          .wait('#agreements-module-display')
+          .click('nav #eresources')
+          .wait('#input-eresource-search')
+          .then(done)
+          .catch(done);
+      });
+
+      Basket.shouldAddTitleToBasket(nightmare, 1, basket);
+
+      it(`should create agreement: ${values.name}`, function _(done) {
+        AgreementCRUD.createAgreement(nightmare, done, values, basket[0].id);
+      });
+
+      // Eresources accordion should expand as part of this call.
+      Basket.shouldHaveCorrectAgreementLines(nightmare, [0], basket);
+
+      // Eresources accordion should now be expanded.
+      it('should not have any custom coverage indicators', done => {
+        nightmare
+          .evaluate(() => {
+            let element;
+
+            element = document.querySelector('#agreement-lines [data-test-custom-coverage');
+            if (element) throw Error('Found an unexpected custom coverage icon in "agreement lines" table.');
+
+            element = document.querySelector('#eresources-covered [data-test-custom-coverage');
+            if (element) throw Error('Found an unexpected custom coverage icon in "eresources covered" table.');
+          }, values)
+          .then(done)
+          .catch(done);
+      });
+
+      it('should edit agreement and add custom coverage', done => {
+        let chain = nightmare
+          .click('[class*=paneHeader] [class*=dropdown] button')
+          .wait('#clickable-edit-agreement')
+          .click('#clickable-edit-agreement')
+          .wait('#agreementFormInfo')
+          .waitUntilNetworkIdle(2000)
+
+          .click('#accordion-toggle-button-agreementFormLines');
+
+        values.coverage.forEach((coverage, i) => {
+          chain = chain
+            .click('#agreement-form-lines [data-test-ag-line-number="0"] #add-agreement-custom-coverage-button')
+            .insert(`#cc-start-date-${i}`, coverage.startDate)
+            .insert(`#cc-start-volume-${i}`, coverage.startVolume)
+            .insert(`#cc-start-issue-${i}`, coverage.startIssue)
+            .insert(`#cc-end-date-${i}`, coverage.endDate)
+            .insert(`#cc-end-volume-${i}`, coverage.endVolume)
+            .insert(`#cc-end-issue-${i}`, coverage.endIssue);
+        });
+
+        chain
+          .click('#clickable-updateagreement')
+          .wait('#agreementInfo')
+          .waitUntilNetworkIdle(2000) // Wait for the POST/reloading to trigger since #agreementInfo may be up for some ms first.
+          .then(done)
+          .catch(done);
+      });
+
+      it('should have custom coverage indicator in agreement lines table', done => {
+        checkTableForCustomCoverageIcon(nightmare, done, 'agreement-lines');
+      });
+
+      it('should have custom coverages listed in agreement lines table', done => {
+        checkTableForCustomCoverageData(nightmare, done, 'agreement-lines', values);
+      });
+
+      it('should have custom coverage indicator in eresources covered table', done => {
+        checkTableForCustomCoverageIcon(nightmare, done, 'eresources-covered');
+      });
+
+      it('should have custom coverages listed in eresources covered table', done => {
+        checkTableForCustomCoverageData(nightmare, done, 'eresources-covered', values);
+      });
+
+      it('should edit agreement and see previously-set custom coverages', done => {
+        nightmare
+          .click('[class*=paneHeader] [class*=dropdown] button')
+          .wait('#clickable-edit-agreement')
+          .click('#clickable-edit-agreement')
+          .wait('#agreementFormInfo')
+          .waitUntilNetworkIdle(2000)
+
+          .click('#accordion-toggle-button-agreementFormLines')
+
+          .click('#agreement-form-lines [data-test-ag-line-number="0"] #add-agreement-custom-coverage-button')
+          .evaluate((expectedValues) => {
+            const checkInput = (id, value) => {
+              const loadedValue = document.getElementById(id).value;
+              if (loadedValue !== value) {
+                throw Error(`Incorrect loaded value of "${loadedValue}" for #${id}. Expected ${value}`);
+              }
+            };
+
+            for (let i = 0; i < expectedValues.coverage.length; i++) {
+              const startDate = document.getElementById(`cc-start-date-${i}`).value;
+              const ec = expectedValues.coverage.find(c => c.startDate === startDate);
+              if (!ec) throw Error(`Incorrectly set coverage. No start date of ${startDate} is expected.`);
+
+              checkInput(`cc-start-date-${i}`, ec.startDate);
+              checkInput(`cc-start-volume-${i}`, ec.startVolume);
+              checkInput(`cc-start-issue-${i}`, ec.startIssue);
+              checkInput(`cc-end-date-${i}`, ec.endDate);
+              checkInput(`cc-end-volume-${i}`, ec.endVolume);
+              checkInput(`cc-end-issue-${i}`, ec.endIssue);
+            }
+          }, values)
+          .click('#form-agreement [class*="paneHeader"] button[icon="times"]')
+          .then(done)
+          .catch(done);
+      });
+    });
+  });
+};

--- a/test/ui-testing/nav.js
+++ b/test/ui-testing/nav.js
@@ -1,7 +1,7 @@
 /* global describe, it, before, after, Nightmare */
 
 module.exports.test = (uiTestCtx) => {
-  describe('Module test: ui-agreements: tab navigation', function test() {
+  describe('ui-agreements: tab navigation', function test() {
     const { config, helpers: { login, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 

--- a/test/ui-testing/utils.js
+++ b/test/ui-testing/utils.js
@@ -3,5 +3,5 @@
 module.exports.formattedDate = function formattedDate(datestring) {
   const date = new Date(datestring);
 
-  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}}`;
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`;
 };

--- a/test/ui-testing/utils.js
+++ b/test/ui-testing/utils.js
@@ -1,0 +1,7 @@
+// Utilities for tests in this repo.
+
+module.exports.formattedDate = function formattedDate(datestring) {
+  const date = new Date(datestring);
+
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}}`;
+};

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -130,6 +130,8 @@
   "eresources.addToBasketHeader": "E-resource basket",
   "eresources.sourceKb": "Source",
 
+  "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
+
   "license.addExternalLicense": "Add external license to agreement",
   "license.addLicense": "Add license to agreement",
   "license.allLicenses": "All licenses",

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -58,6 +58,7 @@
   "agreements.editAgreement": "Edit Agreement",
 
   "agreementLines.addLine": "Add agreement line",
+  "agreementLines.addCustomCoverage": "Add custom coverage",
   "agreementLines.costType": "Cost type",
   "agreementLines.count": "Count",
   "agreementLines.contentUpdated": "Content updated",
@@ -70,6 +71,7 @@
   "agreementLines.tax": "YTD Tax",
   "agreementLines.createLine": "Create agreement line",
   "agreementLines.lineTitle": "Agreement line #{number}",
+  "agreementLines.customCoverageTitle": "Custom coverage #{number}",
 
   "basketButton": "View {count, number} {count, plural, one {item} other {items}}",
   "basket.name": "ERM Basket",


### PR DESCRIPTION
Feature
- Set custom coverage for agreement lines
  - Not available for agreement lines for packages
- View coverages on the agreement-lines, eresources-covered, and agreement-lines-for-eresource tables
- View custom coverage indicators (`<CustomCoverageIcon>` on aforementioned tables
  - Icon will be changed after Q1 code freeze. Need to get icon into stripes-components and don't want to depend on a version of stripes-components that won't be in Q1.
- Tests

Reusables
- Added `withKiwtFieldArray` HOC to handle all the nuances of the arrays used by the backend.
- Added `<EditCard>` component for field array items.