### PR TITLE
Cleaned up indents of agreement subaccordions

### DIFF
--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormInfo.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormInfo.js
@@ -6,7 +6,6 @@ import { Field } from 'redux-form';
 
 import {
   Accordion,
-  AccordionSet,
   Col,
   Datepicker,
   Row,
@@ -162,11 +161,14 @@ class AgreementFormInfo extends React.Component {
             />
           </Col>
         </Row>
-        <AccordionSet>
-          <Accordion label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}>
+        <div style={{ marginLeft: '2rem' }}>
+          <Accordion
+            closedByDefault
+            label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}
+          >
             <AgreementFormInternalContacts {...sectionProps} />
           </Accordion>
-        </AccordionSet>
+        </div>
       </Accordion>
     );
   }

--- a/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
+++ b/src/components/Agreements/AgreementForm/Sections/AgreementFormOrganizations.js
@@ -13,7 +13,6 @@ import {
   Layout,
   Row,
   Select,
-  Icon,
 } from '@folio/stripes/components';
 
 import {
@@ -115,9 +114,7 @@ class AgreementFormOrganizations extends React.Component {
           ))}
         </div>
         <Button onClick={() => fields.push({ })}>
-          <Icon icon="plus-sign">
-            <FormattedMessage id="ui-agreements.organizations.add" />
-          </Icon>
+          <FormattedMessage id="ui-agreements.organizations.add" />
         </Button>
       </div>
     );

--- a/src/components/Agreements/ViewAgreement/Sections/AllLicenses.js
+++ b/src/components/Agreements/ViewAgreement/Sections/AllLicenses.js
@@ -94,7 +94,7 @@ export default class AllLicenses extends React.Component {
 
     if (!licenses.length) {
       return (
-        <Layout className="margin-start-gutter padding-bottom-gutter">
+        <Layout className="padding-bottom-gutter">
           <FormattedMessage id="ui-agreements.license.noLicenses" />
         </Layout>
       );

--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -39,10 +39,12 @@ export default class Eresources extends React.Component {
           visible={open}
           {...this.props}
         />
-        <EresourcesCovered
-          visible={open}
-          {...this.props}
-        />
+        <div style={{ marginLeft: '2rem' }}>
+          <EresourcesCovered
+            visible={open}
+            {...this.props}
+          />
+        </div>
       </Accordion>
     );
   }

--- a/src/components/Agreements/ViewAgreement/Sections/Finances.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Finances.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Accordion, Badge, Button, Icon, Layout } from '@folio/stripes/components';
+import { Accordion, Badge, Icon, Layout } from '@folio/stripes/components';
 
 import FinancesAgreementLines from './FinancesAgreementLines';
 
@@ -34,32 +34,21 @@ export default class Finances extends React.Component {
   render() {
     const { id, onToggle, open } = this.props;
 
-    const buttonAndBadge =
-      <div>
-        <Button align="end">
-          <Icon icon="edit">
-            <FormattedMessage id="ui-agreements.agreements.editFinancesAgreementLines" />
-          </Icon>
-        </Button>
-        {' '}
-        {this.renderBadge()}
-      </div>;
-
     return (
       <Accordion
         id={id}
         label={<FormattedMessage id="ui-agreements.agreements.financesAgreementLines" />}
         open={open}
         onToggle={onToggle}
-        displayWhenClosed={buttonAndBadge}
-        displayWhenOpen={buttonAndBadge}
+        displayWhenClosed={this.renderBadge()}
+        displayWhenOpen={this.renderBadge()}
       >
         {this.renderInvoices()}
         <FinancesAgreementLines
           visible={open}
           {...this.props}
         />
-        <div style={{ marginLeft: 20, marginRight: 20 }}>
+        <div style={{ marginLeft: '2rem' }}>
           <Accordion
             id="finance-reports"
             label={<FormattedMessage id="ui-agreements.agreements.financeReports" />}

--- a/src/components/Agreements/ViewAgreement/Sections/FinancesAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/FinancesAgreementLines.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { get } from 'lodash';
-import { Icon, MultiColumnList } from '@folio/stripes/components';
+import { Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 
 export default class FinancesAgreementLines extends React.Component {
   static propTypes = {
@@ -74,7 +74,11 @@ export default class FinancesAgreementLines extends React.Component {
       return <Icon icon="spinner-ellipsis" width="100px" />;
     }
     if (!financesAgreementLines.length) {
-      return <FormattedMessage id="ui-agreements.agreementLines.noPoLines" />;
+      return (
+        <Layout className="padding-bottom-gutter">
+          <FormattedMessage id="ui-agreements.agreementLines.noPoLines" />
+        </Layout>
+      );
     }
 
     return (

--- a/src/components/Agreements/ViewAgreement/Sections/LicenseInfo.js
+++ b/src/components/Agreements/ViewAgreement/Sections/LicenseInfo.js
@@ -40,7 +40,7 @@ export default class LicenseInfo extends React.Component {
             </Col>
           </Row>
         ) : null }
-        <div style={{ marginTop: '1rem', marginLeft: '1rem' }}>
+        <div style={{ marginTop: '1rem', marginLeft: '2rem' }}>
           <AllLicenses agreement={agreement} />
           <ExternalLicenses agreement={agreement} />
         </div>

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -85,16 +85,18 @@ export default class Organizations extends React.Component {
         <Layout className="padding-bottom-gutter">
           { this.renderOrganizations() }
         </Layout>
-        <Accordion
-          id={`${this.props.id}-license`}
-          label={<FormattedMessage id="ui-agreements.agreements.license" />}
-          open={this.state.displayLicenseOrgs}
-          onToggle={this.toggleDisplayLicenseOrgs}
-        >
-          <Layout className="padding-bottom-gutter">
-            { this.renderLicenseOrganizations() }
-          </Layout>
-        </Accordion>
+        <div style={{ marginLeft: '2rem' }}>
+          <Accordion
+            id={`${this.props.id}-license`}
+            label={<FormattedMessage id="ui-agreements.agreements.license" />}
+            open={this.state.displayLicenseOrgs}
+            onToggle={this.toggleDisplayLicenseOrgs}
+          >
+            <Layout className="padding-bottom-gutter">
+              { this.renderLicenseOrganizations() }
+            </Layout>
+          </Accordion>
+        </div>
       </Accordion>
     );
   }


### PR DESCRIPTION
We have accordions inside of accordions in several places on the View and Edit Agreement pages. These accordions should be uniformly indented to show their relationship to the parent.