### PR TITLE
ERM-128: Prevent multiple open-ended custom coverages from being saved

### DIFF
--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -65,7 +65,7 @@ class CustomCoverageFieldArray extends React.Component {
 
     if (openEndedCoverages > 1) {
       return (
-        <div data-test-error-end-date-too-early>
+        <div data-test-error-multiple-open-ended>
           <FormattedMessage id="ui-agreements.errors.multipleOpenEndedCoverages" />
         </div>
       );

--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -55,6 +55,25 @@ class CustomCoverageFieldArray extends React.Component {
     return undefined;
   }
 
+  validateMultipleOpenEnded = (_value, allValues, _props, name) => {
+    // Name is something like "items[3].coverage[2].endDate" and we want the "items[3].coverage" array
+    const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')));
+    let openEndedCoverages = 0;
+    coverages.forEach(c => {
+      if (!c.endDate) openEndedCoverages += 1;
+    });
+
+    if (openEndedCoverages > 1) {
+      return (
+        <div data-test-error-end-date-too-early>
+          <FormattedMessage id="ui-agreements.errors.multipleOpenEndedCoverages" />
+        </div>
+      );
+    }
+
+    return undefined;
+  }
+
   handleAddCustomCoverage = () => {
     this.props.onAddField({});
   }
@@ -80,7 +99,11 @@ class CustomCoverageFieldArray extends React.Component {
                 label="Start date"
                 name={`${name}[${index}].startDate`}
                 required
-                validate={[required, this.validateDateOrder]}
+                validate={[
+                  required,
+                  this.validateDateOrder,
+                  this.validateMultipleOpenEnded,
+                ]}
               />
             </Col>
             <Col xs={4}>
@@ -109,7 +132,10 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-end-date-${index}`}
                 label="End date"
                 name={`${name}[${index}].endDate`}
-                validate={this.validateDateOrder}
+                validate={[
+                  this.validateDateOrder,
+                  this.validateMultipleOpenEnded,
+                ]}
               />
             </Col>
             <Col xs={4}>

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -132,6 +132,7 @@
   "eresources.sourceKb": "Source",
 
   "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
+  "errors.multipleOpenEndedCoverages": "Cannot have multiple open-ended coverage statements.",
 
   "license.addExternalLicense": "Add external license to agreement",
   "license.addLicense": "Add license to agreement",


### PR DESCRIPTION
Added a new `validate` check to ensure multiple open-ended custom coverages cannot be set for a single agreement line.