### PR TITLE
ERM-128: Additional fix for multiple open-ended coverages

### DIFF
--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -60,7 +60,7 @@ class CustomCoverageFieldArray extends React.Component {
     const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')));
     let openEndedCoverages = 0;
     coverages.forEach(c => {
-      if (!c.endDate) openEndedCoverages += 1;
+      if (c.startDate && !c.endDate) openEndedCoverages += 1;
     });
 
     if (openEndedCoverages > 1) {


### PR DESCRIPTION
Coverages that were previously saved but now deleted were being interpreted as open-ended coverages because of the non-existence of an `endDate` on their `coverage` object. 