### PR TITLE
Coverage: Prevent undefined array dereference

### DIFF
--- a/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/CustomCoverageFieldArray.js
@@ -57,7 +57,7 @@ class CustomCoverageFieldArray extends React.Component {
 
   validateMultipleOpenEnded = (_value, allValues, _props, name) => {
     // Name is something like "items[3].coverage[2].endDate" and we want the "items[3].coverage" array
-    const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')));
+    const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')), []);
     let openEndedCoverages = 0;
     coverages.forEach(c => {
       if (c.startDate && !c.endDate) openEndedCoverages += 1;
@@ -76,7 +76,7 @@ class CustomCoverageFieldArray extends React.Component {
 
   validateOverlappingDates = (value, allValues, _props, name) => {
     // Name is something like "items[3].coverage[2].endDate" and we want the "items[3].coverage" array
-    const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')));
+    const coverages = get(allValues, name.substring(0, name.lastIndexOf('[')), []);
     const ranges = coverages
       .map((c, i) => ({
         coverageIndex: i,


### PR DESCRIPTION
When deleting an agreement line, the validators fire one last time before the item is gone for good (and the validators fire again). In that scenario, the `get` for the `coverage` array can fail because the `items[x]` doesn't exist.

Added a default empty coverage array so that the validators return no error in that run.