### PR TITLE
ERM-109/110 eHoldings Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "stripes serve",
     "build": "stripes build --output ./output",
     "test": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses/custom-coverage/hide-eresources-func",
+    "test-int": "stripes test nightmare --run nav/agreement-crud/basket/external-licenses/custom-coverage/hide-eresources-func/linked-licenses/license-terms",
     "test-nav": "stripes test nightmare --run nav",
     "test-agreement-crud": "stripes test nightmare --run agreement-crud",
     "test-basket": "stripes test nightmare --run basket",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test-custom-coverage": "stripes test nightmare --run custom-coverage",
     "test-linked-licenses": "stripes test nightmare --run linked-licenses",
     "test-license-terms": "stripes test nightmare --run license-terms",
+    "test-ekb-int": "stripes test nightmare --run ekb-int",
     "lint": "eslint src"
   },
   "devDependencies": {

--- a/src/ERM.js
+++ b/src/ERM.js
@@ -113,7 +113,7 @@ export default class ERM extends React.Component {
   }
 
   render() {
-    const { stripes, match } = this.props;
+    const { location, match } = this.props;
     const currentPage = this.getCurrentPage(this.props);
 
     return (
@@ -126,19 +126,19 @@ export default class ERM extends React.Component {
               parentResources={this.props.resources}
               parentMutator={this.props.mutator}
             />
-            <this.connectedOpenBasketButton stripes={stripes} />
+            <this.connectedOpenBasketButton />
           </Layout>
         </IfEResourcesEnabled>
         <div className={css.body}>
           <Switch>
             <Route
               path={`${match.path}/agreements`}
-              render={() => <this.connectedAgreements stripes={stripes} />}
+              render={() => <this.connectedAgreements location={location} />}
             />
             <IfEResourcesEnabled>
               <Route
                 path={`${match.path}/eresources`}
-                render={() => <this.connectedEResources stripes={stripes} />}
+                render={() => <this.connectedEResources location={location} />}
               />
             </IfEResourcesEnabled>
             <Redirect

--- a/src/components/Agreements/AgreementForm/components/AgreementLineField.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLineField.js
@@ -12,7 +12,10 @@ import {
 
 import BasketSelector from '../../../BasketSelector';
 import EResourceLink from '../../../EResourceLink';
+import ResourceCount from '../../../ResourceCount';
+import ResourceProvider from '../../../ResourceProvider';
 import ResourceType from '../../../ResourceType';
+import isExternal from '../../../../util/isExternal';
 import isPackage from '../../../../util/isPackage';
 
 import CustomCoverageFieldArray from './CustomCoverageFieldArray';
@@ -32,8 +35,8 @@ export default class AgreementLineField extends React.Component {
   }
 
   renderLineName = (resource) => {
-    const title = get(resource, ['_object', 'pti', 'titleInstance'], resource);
-    return <EResourceLink eresource={title} />;
+    const dereferencedResource = get(resource, ['_object', 'pti', 'titleInstance'], resource);
+    return <EResourceLink eresource={dereferencedResource} />;
   }
 
   renderLineType = (resource) => {
@@ -41,21 +44,18 @@ export default class AgreementLineField extends React.Component {
   }
 
   renderLineTitles = (resource) => {
-    // If contentItems doesn't exist there's only one item.
-    return get(resource, ['_object', 'contentItems'], [0]).length;
+    return <ResourceCount resource={resource} />;
   }
 
-  renderLinePlatform = (resource) => {
-    return (
-      get(resource, ['_object', 'pti', 'platform', 'name']) ||
-      get(resource, ['_object', 'nominalPlatform', 'name'])
-    );
+  renderLineProvider = (resource) => {
+    return <ResourceProvider resource={resource} />;
   }
 
   renderCustomCoverageSelector = () => {
     const { resource } = this.props;
 
     if (isPackage(resource)) return null;
+    if (isExternal(resource)) return null;
 
     return (
       <FieldArray
@@ -66,7 +66,7 @@ export default class AgreementLineField extends React.Component {
   }
 
   renderLineResource = () => {
-    const { resource } = this.props;
+    const { resource = {} } = this.props;
 
     return (
       <React.Fragment>
@@ -87,8 +87,8 @@ export default class AgreementLineField extends React.Component {
             </KeyValue>
           </Col>
           <Col xs={12} md={3}>
-            <KeyValue label={<FormattedMessage id="ui-agreements.eresources.platform" />}>
-              <div data-test-ag-line-platform>{this.renderLinePlatform(resource)}</div>
+            <KeyValue label={<FormattedMessage id="ui-agreements.eresources.provider" />}>
+              <div data-test-ag-line-provider>{this.renderLineProvider(resource)}</div>
             </KeyValue>
           </Col>
         </Row>
@@ -116,7 +116,7 @@ export default class AgreementLineField extends React.Component {
         onDelete={this.props.onDelete}
       >
         {
-          resource.id ?
+          (resource.id || resource.reference) ?
             this.renderLineResource() :
             this.renderLineSelector()
         }

--- a/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { get } from 'lodash';
 
 import { Button, Layout } from '@folio/stripes/components';
 

--- a/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
+++ b/src/components/Agreements/AgreementForm/components/AgreementLinesFieldArray.js
@@ -1,16 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { get } from 'lodash';
 
-import {
-  Button,
-  Layout,
-} from '@folio/stripes/components';
+import { Button, Layout } from '@folio/stripes/components';
 
 import { withKiwtFieldArray } from '@folio/stripes-erm-components';
 
 import IfEResourcesEnabled from '../../../IfEResourcesEnabled';
 import AgreementLineField from './AgreementLineField';
+import isExternal from '../../../../util/isExternal';
 
 class AgreementLinesFieldArray extends React.Component {
   static propTypes = {
@@ -28,14 +27,24 @@ class AgreementLinesFieldArray extends React.Component {
 
     if (line.resource) return line.resource;
 
+    if (agreementLines) {
+      const foundLine = agreementLines.find(l => l.id === line.id);
+      if (foundLine) {
+        if (isExternal(foundLine)) {
+          return foundLine;
+        } else {
+          return foundLine.resource;
+        }
+      }
+    }
+
     if (parentResources && parentResources.basket) {
       const basketLine = parentResources.basket.find(l => l.id === line.id);
       if (basketLine) return basketLine;
     }
 
-    if (agreementLines) {
-      const foundLine = agreementLines.find(l => l.id === line.id);
-      if (foundLine) return foundLine.resource;
+    if (isExternal(line)) {
+      return line;
     }
 
     return undefined;
@@ -69,7 +78,7 @@ class AgreementLinesFieldArray extends React.Component {
     ));
   }
 
-  render = () => {
+  render() {
     return (
       <div>
         <div id="agreement-form-lines">

--- a/src/components/Agreements/EditAgreement/EditAgreement.js
+++ b/src/components/Agreements/EditAgreement/EditAgreement.js
@@ -45,23 +45,32 @@ class EditAgreement extends React.Component {
     }
 
     // The value of the `items` field can be fed by the basket or if we're _editing_, the
-    // previously-persisted values. We need to merge these two arrays when we get that data changes.s
+    // previously-persisted values. We need to merge these two arrays when we get those data changes.
+    const externalAgreementLine = get(this.props.parentResources.externalAgreementLine, ['records', 0]);
     if (
       !isEqual(this.props.initialValues, prevProps.initialValues) ||
-      !isEqual(this.state.addedResourcesFromBasket, prevState.addedResourcesFromBasket)
+      !isEqual(this.state.addedResourcesFromBasket, prevState.addedResourcesFromBasket) ||
+      !isEqual(externalAgreementLine, get(prevProps.parentResources.externalAgreementLine, ['records', 0]))
     ) {
-      this.props.change(
-        'items',
-        [
-          ...get(this.props, ['initialValues', 'items'], []),
-          ...this.state.addedResourcesFromBasket,
-        ]
-      );
+      const items = [
+        ...get(this.props, ['initialValues', 'items'], []),
+        ...this.state.addedResourcesFromBasket,
+      ];
+
+      if (externalAgreementLine) {
+        items.push(externalAgreementLine);
+      }
+
+      this.props.change('items', items);
     }
   }
 
   componentWillUnmount() {
-    this.props.parentMutator.query.replace({ addFromBasket: null });
+    this.props.parentMutator.query.replace({
+      addFromBasket: null,
+      authority: null,
+      referenceId: null,
+    });
   }
 
   updateAddedResourcesFromBasket() {

--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -11,6 +11,7 @@ import ResourceType from '../../../ResourceType';
 import CoverageStatements from '../../../CoverageStatements';
 import CustomCoverageIcon from '../../../CustomCoverageIcon';
 import getResourceFromEntitlement from '../../../../util/getResourceFromEntitlement';
+
 export default class EresourceAgreementLines extends React.Component {
   static propTypes = {
     agreementLines: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -5,10 +5,12 @@ import { get } from 'lodash';
 import { Icon, Layout, MultiColumnList } from '@folio/stripes/components';
 
 import EResourceLink from '../../../EResourceLink';
+import ResourceCount from '../../../ResourceCount';
+import ResourceProvider from '../../../ResourceProvider';
 import ResourceType from '../../../ResourceType';
 import CoverageStatements from '../../../CoverageStatements';
 import CustomCoverageIcon from '../../../CustomCoverageIcon';
-
+import getResourceFromEntitlement from '../../../../util/getResourceFromEntitlement';
 export default class EresourceAgreementLines extends React.Component {
   static propTypes = {
     agreementLines: PropTypes.arrayOf(PropTypes.object),
@@ -17,7 +19,7 @@ export default class EresourceAgreementLines extends React.Component {
 
   columnWidths = {
     name: 250,
-    platform: 150,
+    provider: 150,
     type: 100,
     coverage: 225,
     isCustomCoverage: 30,
@@ -25,7 +27,7 @@ export default class EresourceAgreementLines extends React.Component {
 
   columnMapping = {
     name: <FormattedMessage id="ui-agreements.eresources.name" />,
-    platform: <FormattedMessage id="ui-agreements.eresources.platform" />,
+    provider: <FormattedMessage id="ui-agreements.eresources.provider" />,
     type: <FormattedMessage id="ui-agreements.eresources.erType" />,
     count: <FormattedMessage id="ui-agreements.agreementLines.count" />,
     coverage: <FormattedMessage id="ui-agreements.eresources.coverage" />,
@@ -34,30 +36,29 @@ export default class EresourceAgreementLines extends React.Component {
 
   formatter = {
     name: line => {
-      const resource = get(line.resource, ['_object', 'pti', 'titleInstance'], line.resource);
-
+      const resource = getResourceFromEntitlement(line);
       if (!resource) return line.label;
 
       return (
         <EResourceLink
           eresource={resource}
-          linkProps={{ 'data-test-resource-id': line.resource.id }}
+          linkProps={{
+            'data-test-resource-id': get(line, ['resource', 'id']),
+            'data-test-external-reference': line.reference,
+          }}
         />
       );
     },
-    platform: line => (
-      get(line, ['resource', '_object', 'pti', 'platform', 'name']) ||
-      get(line, ['resource', '_object', 'nominalPlatform', 'name'])
-    ),
-    type: line => <ResourceType resource={line.resource} />,
-    count: line => (get(line, ['_object', 'contentItems'], [0])).length, // If contentItems doesn't exist there's only one item.
+    provider: line => <ResourceProvider resource={line.resource || line} />,
+    type: line => <ResourceType resource={getResourceFromEntitlement(line)} />,
+    count: line => <ResourceCount resource={getResourceFromEntitlement(line)} />,
     coverage: line => <CoverageStatements statements={line.coverage} />,
     isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : ''),
   }
 
   visibleColumns = [
     'name',
-    'platform',
+    'provider',
     'type',
     'count',
     'coverage',

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -43,7 +43,6 @@ class ViewAgreement extends React.Component {
       type: 'okapi',
       path: 'erm/sas/:{id}',
       shouldRefresh,
-      throwErrors: false,
     },
     agreementLines: {
       type: 'okapi',
@@ -53,7 +52,6 @@ class ViewAgreement extends React.Component {
         term: ':{id}',
       },
       shouldRefresh,
-      throwErrors: false,
     },
     contacts: {
       type: 'okapi',
@@ -63,7 +61,6 @@ class ViewAgreement extends React.Component {
         term: ':{id}',
       },
       shouldRefresh,
-      throwErrors: false,
     },
     financesAgreementLines: {
       type: 'okapi',
@@ -80,7 +77,6 @@ class ViewAgreement extends React.Component {
       type: 'okapi',
       path: 'invoice-storage/invoice-lines',
       records: 'invoiceLines',
-      throwErrors: false,
       fetch: false,
       accumulate: true,
     },
@@ -102,7 +98,6 @@ class ViewAgreement extends React.Component {
       path: '/users',
       fetch: false,
       accumulate: true,
-      throwErrors: false,
     },
     agreementEresourcesCount: { initialValue: ERESOURCES_RESULTS_INTERVAL },
     query: {},

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -43,6 +43,7 @@ class ViewAgreement extends React.Component {
       type: 'okapi',
       path: 'erm/sas/:{id}',
       shouldRefresh,
+      throwErrors: false,
     },
     agreementLines: {
       type: 'okapi',
@@ -52,6 +53,7 @@ class ViewAgreement extends React.Component {
         term: ':{id}',
       },
       shouldRefresh,
+      throwErrors: false,
     },
     contacts: {
       type: 'okapi',
@@ -61,6 +63,7 @@ class ViewAgreement extends React.Component {
         term: ':{id}',
       },
       shouldRefresh,
+      throwErrors: false,
     },
     financesAgreementLines: {
       type: 'okapi',
@@ -99,6 +102,7 @@ class ViewAgreement extends React.Component {
       path: '/users',
       fetch: false,
       accumulate: true,
+      throwErrors: false,
     },
     agreementEresourcesCount: { initialValue: ERESOURCES_RESULTS_INTERVAL },
     query: {},

--- a/src/components/Basket/BasketList.js
+++ b/src/components/Basket/BasketList.js
@@ -13,7 +13,6 @@ import CoverageStatements from '../CoverageStatements';
 import EResourceLink from '../EResourceLink';
 import ResourceType from '../ResourceType';
 
-
 class BasketList extends React.Component {
   static propTypes = {
     basket: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/EResourceLink/EResourceLink.js
+++ b/src/components/EResourceLink/EResourceLink.js
@@ -26,7 +26,7 @@ class EResourceLink extends React.Component {
     const { authority, id, reference } = eresource;
 
     if (!authority && id) {
-      return `/erm/eresources/view/${id}`
+      return `/erm/eresources/view/${id}`;
     }
 
     if (authority === 'EKB-PACKAGE') {

--- a/src/components/EResourceLink/EResourceLink.js
+++ b/src/components/EResourceLink/EResourceLink.js
@@ -1,36 +1,58 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStripes } from '@folio/stripes/core';
+
 import FolioLink from '../FolioLink';
+import isExternal from '../../util/isExternal';
 
 class EResourceLink extends React.Component {
   static propTypes = {
     eresource: PropTypes.shape({
+      authority: PropTypes.string,
       id: PropTypes.string,
       name: PropTypes.string,
+      reference: PropTypes.string,
     }).isRequired,
-    stripes: PropTypes.shape({
-      connect: PropTypes.func,
-    }),
   }
 
-  constructor(props) {
-    super(props);
+  getName = (eresource) => {
+    if (isExternal(eresource)) {
+      return eresource.reference_object.label;
+    }
 
-    this.connectedFolioLink = props.stripes.connect(FolioLink);
+    return eresource.name;
+  }
+
+  getPath = (eresource) => {
+    const { authority, id, reference } = eresource;
+
+    if (!authority && id) {
+      return `/erm/eresources/view/${id}`
+    }
+
+    if (authority === 'EKB-PACKAGE') {
+      return `/eholdings/packages/${reference}`;
+    }
+
+    if (authority === 'EKB-TITLE') {
+      return `/eholdings/resources/${reference}`;
+    }
+
+    return undefined;
   }
 
   render() {
-    const { eresource: { id, name }, ...rest } = this.props;
+    const { eresource, ...rest } = this.props;
 
-    if (!id) return name;
+    const name = this.getName(eresource);
+    const path = this.getPath(eresource);
+    if (!path) return name;
 
     return (
-      <this.connectedFolioLink {...rest} path={`/erm/eresources/view/${id}`}>
+      <FolioLink {...rest} path={this.getPath(eresource)}>
         {name}
-      </this.connectedFolioLink>
+      </FolioLink>
     );
   }
 }
 
-export default withStripes(EResourceLink);
+export default EResourceLink;

--- a/src/components/EResources/EResourceAgreements/EResourceAgreements.js
+++ b/src/components/EResources/EResourceAgreements/EResourceAgreements.js
@@ -12,6 +12,7 @@ import EResourceLink from '../../EResourceLink';
 import ResourceType from '../../ResourceType';
 import CoverageStatements from '../../CoverageStatements';
 import CustomCoverageIcon from '../../CustomCoverageIcon';
+import getResourceFromEntitlement from '../../../util/getResourceFromEntitlement';
 
 class EResourceAgreements extends React.Component {
   static manifest = Object.freeze({
@@ -52,7 +53,7 @@ class EResourceAgreements extends React.Component {
     type: ({ owner }) => owner.agreementStatus && owner.agreementStatus.label,
     startDate: ({ owner }) => owner.startDate && <FormattedDate value={owner.startDate} />,
     endDate: ({ owner }) => owner.endDate && <FormattedDate value={owner.endDate} />,
-    package: ({ resource }) => <EResourceLink eresource={resource} />,
+    package: (line) => <EResourceLink eresource={getResourceFromEntitlement(line)} />,
     acqMethod: ({ resource }) => <ResourceType resource={resource} />,
     coverage: line => <CoverageStatements statements={line.coverage} />,
     isCustomCoverage: line => (line.customCoverage ? <CustomCoverageIcon /> : ''),

--- a/src/components/FolioLink/FolioLink.js
+++ b/src/components/FolioLink/FolioLink.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 
+import { stripesConnect } from '@folio/stripes/core';
+
 class FolioLink extends React.Component {
   static manifest = Object.freeze({
     query: {},
@@ -48,4 +50,4 @@ class FolioLink extends React.Component {
   }
 }
 
-export default FolioLink;
+export default stripesConnect(FolioLink);

--- a/src/components/ResourceCount/ResourceCount.js
+++ b/src/components/ResourceCount/ResourceCount.js
@@ -25,6 +25,6 @@ export default class ResourceCount extends React.Component {
     }
 
     // If contentItems doesn't exist there's only one item.
-    return get(resource, ['_object', 'contentItems', 'length'], 1)
+    return get(resource, ['_object', 'contentItems', 'length'], 1);
   }
 }

--- a/src/components/ResourceCount/ResourceCount.js
+++ b/src/components/ResourceCount/ResourceCount.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+
+import isExternal from '../../util/isExternal';
+
+export default class ResourceCount extends React.Component {
+  static propTypes = {
+    resource: PropTypes.shape({
+      _object: PropTypes.shape({
+        contentItems: PropTypes.array,
+      }),
+      reference_object: PropTypes.shape({
+        titleCount: PropTypes.number,
+      }),
+    })
+  }
+
+  render() {
+    const { resource } = this.props;
+    if (!resource) return null;
+
+    if (isExternal(resource)) {
+      return get(resource, ['reference_object', 'titleCount'], 1);
+    }
+
+    // If contentItems doesn't exist there's only one item.
+    return get(resource, ['_object', 'contentItems', 'length'], 1)
+  }
+}

--- a/src/components/ResourceCount/index.js
+++ b/src/components/ResourceCount/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResourceCount';

--- a/src/components/ResourceProvider/ResourceProvider.js
+++ b/src/components/ResourceProvider/ResourceProvider.js
@@ -33,5 +33,3 @@ export default class ResourceProvider extends React.Component {
     );
   }
 }
-
-

--- a/src/components/ResourceProvider/ResourceProvider.js
+++ b/src/components/ResourceProvider/ResourceProvider.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+
+
+export default class ResourceProvider extends React.Component {
+  static propTypes = {
+    resource: PropTypes.shape({
+      _object: PropTypes.shape({
+        nominalPlatform: PropTypes.shape({
+          name: PropTypes.string,
+        }),
+        pti: PropTypes.shape({
+          platform: PropTypes.shape({
+            name: PropTypes.string,
+          })
+        })
+      }),
+      reference_object: PropTypes.shape({
+        provider: PropTypes.string,
+      })
+    })
+  }
+
+  render() {
+    const { resource } = this.props;
+
+    return (
+      get(resource, ['_object', 'pti', 'platform', 'name']) ||
+      get(resource, ['_object', 'nominalPlatform', 'name']) ||
+      get(resource, ['reference_object', 'provider']) ||
+      null
+    );
+  }
+}
+
+

--- a/src/components/ResourceProvider/index.js
+++ b/src/components/ResourceProvider/index.js
@@ -1,0 +1,1 @@
+export { default } from './ResourceProvider';

--- a/src/components/ResourceType/ResourceType.js
+++ b/src/components/ResourceType/ResourceType.js
@@ -8,7 +8,6 @@ import isPackage from '../../util/isPackage';
 export default class ResourceType extends React.Component {
   static propTypes = {
     resource: PropTypes.shape({
-      class: PropTypes.string,
       _object: PropTypes.shape({
         pti: PropTypes.shape({
           titleInstance: PropTypes.shape({
@@ -16,23 +15,29 @@ export default class ResourceType extends React.Component {
           })
         })
       }),
-      type: PropTypes.shape({
-        label: PropTypes.string,
-      })
+      reference_object: PropTypes.shape({
+        type: PropTypes.string,
+      }),
+      type: PropTypes.oneOfType([
+        PropTypes.shape({ label: PropTypes.string }),
+        PropTypes.string,
+      ])
     })
   }
 
   render() {
     const { resource } = this.props;
-    if (!resource) return '';
+    if (!resource) return null;
 
     if (isPackage(resource)) {
       return <FormattedMessage id="ui-agreements.eresources.package" />;
     }
 
-    let type = get(resource, ['_object', 'pti', 'titleInstance', 'type', 'label']);
-    if (!type) type = get(resource, ['type', 'label']);
-
-    return type || <FormattedMessage id="ui-agreements.eresources.title" />;
+    return (
+      get(resource, ['_object', 'pti', 'titleInstance', 'type', 'label']) ||
+      get(resource, ['reference_object', 'type']) ||
+      get(resource, ['type', 'label']) ||
+      <FormattedMessage id="ui-agreements.eresources.title" />
+    );
   }
 }

--- a/src/routes/Agreements.js
+++ b/src/routes/Agreements.js
@@ -45,6 +45,15 @@ class Agreements extends React.Component {
       path: 'erm/sas/${selectedAgreementId}', // eslint-disable-line no-template-curly-in-string
       fetch: false,
     },
+    externalAgreementLine: {
+      type: 'okapi',
+      path: 'erm/entitlements/external',
+      params: {
+        authority: '?{authority}',
+        reference: '?{referenceId}',
+      },
+      throwErrors: false,
+    },
     terms: {
       type: 'okapi',
       path: 'licenses/custprops',
@@ -186,74 +195,72 @@ class Agreements extends React.Component {
     const { mutator, resources, intl } = this.props;
 
     return (
-      <React.Fragment>
-        <SearchAndSort
-          browseOnly={this.props.browseOnly}
-          columnMapping={{
-            name: intl.formatMessage({ id: 'ui-agreements.agreements.name' }),
-            vendor: intl.formatMessage({ id: 'ui-agreements.agreements.vendorInfo.vendor' }),
-            startDate: intl.formatMessage({ id: 'ui-agreements.agreements.startDate' }),
-            endDate: intl.formatMessage({ id: 'ui-agreements.agreements.endDate' }),
-            cancellationDeadline: intl.formatMessage({ id: 'ui-agreements.agreements.cancellationDeadline' }),
-            agreementStatus: intl.formatMessage({ id: 'ui-agreements.agreements.agreementStatus' }),
-            lastUpdated: intl.formatMessage({ id: 'ui-agreements.lastUpdated' }),
-          }}
-          columnWidths={{
-            name: 300,
-            vendor: 200,
-            startDate: 120,
-            endDate: 120,
-            cancellationDeadline: 120,
-            agreementStatus: 150,
-            lastUpdated: 120,
-          }}
-          detailProps={{
-            onUpdate: this.handleUpdate
-          }}
-          disableRecordCreation={this.props.disableRecordCreation}
-          editRecordComponent={EditAgreement}
-          initialResultCount={INITIAL_RESULT_COUNT}
-          key="agreements"
-          newRecordPerms="ui-agreements.agreements.create"
-          objectName="agreement"
-          onCreate={this.handleCreate}
-          onFilterChange={this.handleFilterChange}
-          onSelectRow={this.props.onSelectRow}
-          packageInfo={this.getPackageInfo()}
-          resultCountIncrement={INITIAL_RESULT_COUNT}
-          showSingleResult={this.props.showSingleResult}
-          viewRecordComponent={ViewAgreement}
-          viewRecordPerms="ui-agreements.agreements.view"
-          // SearchAndSort expects the resource it's going to list to be under the `records` key.
-          // However, if we just put it under `records` in the `manifest`, it would clash with
-          // the `records` that would need to be defined by the Agreements tab.
-          parentMutator={{
-            ...mutator,
-            records: mutator.agreements,
-          }}
-          parentResources={{
-            ...resources,
-            records: resources.agreements,
-          }}
-          renderFilters={this.renderFilters}
-          resultsFormatter={{
-            vendor: a => a.vendor && a.vendor.name,
-            startDate: a => a.startDate && intl.formatDate(a.startDate),
-            endDate: a => a.endDate && intl.formatDate(a.endDate),
-            cancellationDeadline: a => a.cancellationDeadline && intl.formatDate(a.cancellationDeadline),
-            agreementStatus: a => a.agreementStatus && a.agreementStatus.label,
-          }}
-          visibleColumns={[
-            'name',
-            'vendor',
-            'startDate',
-            'endDate',
-            'cancellationDeadline',
-            'agreementStatus',
-            'lastUpdated'
-          ]}
-        />
-      </React.Fragment>
+      <SearchAndSort
+        browseOnly={this.props.browseOnly}
+        columnMapping={{
+          name: intl.formatMessage({ id: 'ui-agreements.agreements.name' }),
+          vendor: intl.formatMessage({ id: 'ui-agreements.agreements.vendorInfo.vendor' }),
+          startDate: intl.formatMessage({ id: 'ui-agreements.agreements.startDate' }),
+          endDate: intl.formatMessage({ id: 'ui-agreements.agreements.endDate' }),
+          cancellationDeadline: intl.formatMessage({ id: 'ui-agreements.agreements.cancellationDeadline' }),
+          agreementStatus: intl.formatMessage({ id: 'ui-agreements.agreements.agreementStatus' }),
+          lastUpdated: intl.formatMessage({ id: 'ui-agreements.lastUpdated' }),
+        }}
+        columnWidths={{
+          name: 300,
+          vendor: 200,
+          startDate: 120,
+          endDate: 120,
+          cancellationDeadline: 120,
+          agreementStatus: 150,
+          lastUpdated: 120,
+        }}
+        detailProps={{
+          onUpdate: this.handleUpdate
+        }}
+        disableRecordCreation={this.props.disableRecordCreation}
+        editRecordComponent={EditAgreement}
+        initialResultCount={INITIAL_RESULT_COUNT}
+        key="agreements"
+        newRecordPerms="ui-agreements.agreements.create"
+        objectName="agreement"
+        onCreate={this.handleCreate}
+        onFilterChange={this.handleFilterChange}
+        onSelectRow={this.props.onSelectRow}
+        packageInfo={this.getPackageInfo()}
+        resultCountIncrement={INITIAL_RESULT_COUNT}
+        showSingleResult={this.props.showSingleResult}
+        viewRecordComponent={ViewAgreement}
+        viewRecordPerms="ui-agreements.agreements.view"
+        // SearchAndSort expects the resource it's going to list to be under the `records` key.
+        // However, if we just put it under `records` in the `manifest`, it would clash with
+        // the `records` that would need to be defined by the Agreements tab.
+        parentMutator={{
+          ...mutator,
+          records: mutator.agreements,
+        }}
+        parentResources={{
+          ...resources,
+          records: resources.agreements,
+        }}
+        renderFilters={this.renderFilters}
+        resultsFormatter={{
+          vendor: a => a.vendor && a.vendor.name,
+          startDate: a => a.startDate && intl.formatDate(a.startDate),
+          endDate: a => a.endDate && intl.formatDate(a.endDate),
+          cancellationDeadline: a => a.cancellationDeadline && intl.formatDate(a.cancellationDeadline),
+          agreementStatus: a => a.agreementStatus && a.agreementStatus.label,
+        }}
+        visibleColumns={[
+          'name',
+          'vendor',
+          'startDate',
+          'endDate',
+          'cancellationDeadline',
+          'agreementStatus',
+          'lastUpdated'
+        ]}
+      />
     );
   }
 }

--- a/src/util/getResourceFromEntitlement.js
+++ b/src/util/getResourceFromEntitlement.js
@@ -1,0 +1,11 @@
+import isExternal from './isExternal';
+import { get } from 'lodash';
+
+export default function getResourceFromEntitlement(line = {}) {
+  if (isExternal(line)) return line;
+
+  const resource = get(line, ['resource', '_object', 'pti', 'titleInstance'], line.resource);
+  if (resource) return resource;
+
+  return { error: 'getResourceFromEntitlement: Failed to find resource' };
+}

--- a/src/util/getResourceFromEntitlement.js
+++ b/src/util/getResourceFromEntitlement.js
@@ -1,5 +1,5 @@
-import isExternal from './isExternal';
 import { get } from 'lodash';
+import isExternal from './isExternal';
 
 export default function getResourceFromEntitlement(line = {}) {
   if (isExternal(line)) return line;

--- a/src/util/isExternal.js
+++ b/src/util/isExternal.js
@@ -1,0 +1,5 @@
+const EXTERNAL_TYPE = 'external';
+
+export default function isExternal(line) {
+  return line.type === EXTERNAL_TYPE;
+}

--- a/test/ui-testing/basket.js
+++ b/test/ui-testing/basket.js
@@ -77,7 +77,7 @@ const shouldHaveCorrectAgreementLines = (nightmare, basketIndices = [], basket =
         basketIndices.forEach(index => {
           const resource = basket[index];
           const line = lines.find(l => l.id === resource.id);
-          if (!line) throw Error(`Could not find agreement line for ${resource.name}`);
+          if (!line) throw Error(`Could not find agreement line for ${resource.name} (${resource.id})`);
           if (line.id !== resource.id) throw Error(`Expected Line #0 ID (${line.id}) to be ${resource.id}`);
           if (line.name !== resource.name) throw Error(`Expected Line #0 Name (${line.name}) to be ${resource.name}`);
           if (line.type !== resource.type) throw Error(`Expected Line #0 Type (${line.type}) to be ${resource.type}`);

--- a/test/ui-testing/ekb-int.js
+++ b/test/ui-testing/ekb-int.js
@@ -1,0 +1,128 @@
+/* global describe, it, before, after, Nightmare */
+
+const getCreateAgreementUrl = ({ authority, referenceId }) => (
+  `/erm/agreements?layer=create&authority=${authority}&referenceId=${referenceId}`
+);
+
+const getEHoldingsUrl = ({ authority, referenceId }) =>  {
+  if (authority === 'EKB-PACKAGE') return `/eholdings/packages/${referenceId}`;
+  if (authority === 'EKB-TITLE') return `/eholdings/resources/${referenceId}`;
+}
+
+module.exports.test = (uiTestCtx) => {
+  describe('ui-agreements: eholdings integration', function test() {
+    const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
+
+    console.log('\n    These tests require the eHoldings backend module (mod-kb-ebsco-java).');
+    console.log('    Ensure it is installed and running before expecting these tests to pass.')
+
+    const resources = [{
+      authority: 'EKB-PACKAGE',
+      referenceId: '301-3707'
+    }, {
+      authority: 'EKB-TITLE',
+      referenceId: '120853-2337939-11517622'
+    }]
+
+    const runValues = resources.map(resource => ({
+      name: `EHoldings Agreement #${Math.round(Math.random() * 100000)}`,
+      createAgreementUrl: `${config.url}${getCreateAgreementUrl(resource)}`,
+      eholdingsUrl: getEHoldingsUrl(resource),
+      authority: resource.authority,
+      referenceId: resource.referenceId,
+    }));
+
+    this.timeout(Number(config.test_timeout));
+
+    describe(`create new agreements with authority/referenceId > check agreement lines`, () => {
+      before((done) => {
+        helpers.login(nightmare, config, done);
+      });
+
+      after((done) => {
+        helpers.logout(nightmare, config, done);
+      });
+
+      runValues.forEach(values => {
+        describe(`authority: ${values.authority}, referenceId: ${values.referenceId}`, () => {
+          it('should open create agreement page with authority/reference query string', done => {
+            nightmare
+              .goto(values.createAgreementUrl)
+              .wait('#edit-agreement-name')
+              .waitUntilNetworkIdle(1000)
+
+              .insert('#edit-agreement-name', values.name)
+              .click('#edit-agreement-start-date')
+              .type('#edit-agreement-start-date', '\u000d') // "Enter" selects current date
+              .type('#edit-agreement-status', 'active')
+              .then(done)
+              .catch(done);
+          });
+
+          it('should have auto-added agreement line with information', done => {
+            nightmare
+              .click('#accordion-toggle-button-agreementFormLines')
+              .evaluate(expected => {
+                if (!document.querySelector('[data-test-ag-line-number]')) {
+                  throw Error(`Failed to find expected agreement line for "${expected.referenceId}".`)
+                }
+
+                if (!document.querySelector('[data-test-ag-line-name]').textContent) {
+                  throw Error('Expected to find a resource name.');
+                }
+
+                if (!document.querySelector(`[data-test-ag-line-name] a[href="${expected.eholdingsUrl}"]`)) {
+                  throw Error(`Expected to find name with URL to "${expected.eholdingsUrl}".`);
+                }
+
+                if (!document.querySelector('[data-test-ag-line-type]').textContent) {
+                  throw Error('Expected to find a resource type.');
+                }
+
+                if (!document.querySelector('[data-test-ag-line-titles]').textContent) {
+                  throw Error('Expected to find a count of titles.');
+                }
+
+                if (!document.querySelector('[data-test-ag-line-provider]').textContent) {
+                  throw Error('Expected to find a resource provider.');
+                }
+              }, values)
+              .then(done)
+              .catch(done);
+          });
+
+          it(`should create agreement ${values.name}`, done => {
+            nightmare
+              .click('#clickable-createagreement')
+              .wait('#agreementInfo')
+              .then(done)
+              .catch(done);
+          });
+
+          it('should check agreement lines listing', done => {
+              nightmare
+              .wait('#accordion-toggle-button-eresourcesAgreementLines')
+              .click('#accordion-toggle-button-eresourcesAgreementLines')
+              .evaluate(expected => {
+                const cells = [...document.querySelectorAll('#agreement-lines [aria-rowindex="2"] [role="gridcell"]')];
+
+                cells.forEach((cell, i) => {
+                  if (i > 3) return;
+                  if (!cell.textContent) {
+                    throw Error(`Expected to find text in agreement line cell #${i}.`);
+                  }
+                });
+
+                if (!cells[0].querySelector(`a[href="${expected.eholdingsUrl}"]`)) {
+                  throw Error(`Expected to find link to "${expected.eholdingsUrl}" in agreement line.`);
+                }
+              }, values)
+              .then(done)
+              .catch(done);
+          });
+        });
+      });
+    });
+  });
+};

--- a/test/ui-testing/ekb-int.js
+++ b/test/ui-testing/ekb-int.js
@@ -14,8 +14,8 @@ module.exports.test = (uiTestCtx) => {
     const { config, helpers } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
-    console.log('\n    These tests require the eHoldings backend module (mod-kb-ebsco-java).');
-    console.log('    Ensure it is installed and running before expecting these tests to pass.')
+    console.log('\n    These tests require eHoldings installed and configured with EBSCO keys.');
+    console.log('    Ensure it is installed, running, and functional before expecting these tests to pass.')
 
     const resources = [{
       authority: 'EKB-PACKAGE',

--- a/test/ui-testing/ekb-int.js
+++ b/test/ui-testing/ekb-int.js
@@ -96,11 +96,12 @@ module.exports.test = (uiTestCtx) => {
             nightmare
               .click('#clickable-createagreement')
               .wait('#agreementInfo')
+              .waitUntilNetworkIdle(2000)
               .then(done)
               .catch(done);
           });
 
-          it('should check agreement lines listing', done => {
+          it('should have resource info in agreement lines list', done => {
               nightmare
               .wait('#accordion-toggle-button-eresourcesAgreementLines')
               .click('#accordion-toggle-button-eresourcesAgreementLines')

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -129,6 +129,7 @@
   "eresources.parentPackage": "Parent package",
   "eresources.acqMethod": "Acquisition method",
   "eresources.platform": "Platform",
+  "eresources.provider": "Provider",
   "eresources.addToBasketHeader": "E-resource basket",
   "eresources.sourceKb": "Source",
 


### PR DESCRIPTION
### ERM-109 - Support creating an agreement w/ an eHoldings package/resource
- Pull `authority` and `referenceId` from query string when creating agreement and use it to lookup package/resource info from `/erm/entitlements/external`.

### ERM-110 - Add support for Agreement Lines table to list external resource
- Lots of generalising and componentising to support different sources of data for external/internal eresources.

### Tests
- `test-ekb-int` to run integration tests for the above features. Naturally, this requires eHoldings to be installed and configured with EBSCO keys.