### PR TITLE
Shrink size of count column

### DIFF
--- a/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
+++ b/src/components/Agreements/ViewAgreement/Sections/EresourceAgreementLines.js
@@ -22,6 +22,7 @@ export default class EresourceAgreementLines extends React.Component {
     name: 250,
     provider: 150,
     type: 100,
+    count: 60,
     coverage: 225,
     isCustomCoverage: 30,
   }


### PR DESCRIPTION
Wasn't necessary to define one before as we were rendering the text/number directly. Now we're rendering a component and MCL has wide default column widths for formatters that return components.