### PR TITLE
ERM-197 Rename ERM to Agreements

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
       },
       {
         "permissionName": "ui-agreements.agreements.view",
-        "displayName": "ERM: Can view agreements",
+        "displayName": "Agreements: Can view agreements",
         "visible": true,
         "subPermissions": [
           "module.agreements.enabled"
@@ -82,7 +82,7 @@
       },
       {
         "permissionName": "ui-agreements.agreements.edit",
-        "displayName": "ERM: Can edit agreements",
+        "displayName": "Agreements: Can edit agreements",
         "visible": true,
         "subPermissions": [
           "ui-agreements.agreements.view"
@@ -90,7 +90,7 @@
       },
       {
         "permissionName": "ui-agreements.agreements.create",
-        "displayName": "ERM: Can create and edit agreements",
+        "displayName": "Agreements: Can create and edit agreements",
         "visible": true,
         "subPermissions": [
           "ui-agreements.agreements.edit"

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -64,7 +64,7 @@ class Tabs extends React.Component {
   }
 
   handleNavigate = (e) => {
-    const { id } = e.target;
+    const { id } = e.currentTarget;
 
     this.persistSortAndFilters();
 

--- a/src/routes/Dashboard.js
+++ b/src/routes/Dashboard.js
@@ -4,7 +4,7 @@ export default class Dashboard extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <h2>Welcome to your ERM Dashboard!</h2>
+        <h2>Welcome to your Agreements Dashboard!</h2>
       </React.Fragment>
     );
   }

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -1,5 +1,5 @@
 {
-  "meta.title": "ERM",
+  "meta.title": "Agreements",
   "lastUpdated": "Last updated",
   "remove": "Remove",
   "yes": "Yes",

--- a/translations/ui-agreements/en_US.json
+++ b/translations/ui-agreements/en_US.json
@@ -61,7 +61,7 @@
     "eresources.acqMethod": "Acquisition method",
     "eresources.platform": "Platform",
     "eresources.addToBasketHeader": "E-resource basket",
-    "meta.title": "ERM",
+    "meta.title": "Agreements",
     "remove": "Remove",
     "yes": "Yes",
     "no": "No",


### PR DESCRIPTION
Handled the display-side renaming of "ERM" to "Agreements".

This does not change any URLs and the underlying module is already called `ui-agreements` so we're fine on that front.

This also fixes a bug that happened when you clicked on a particular part of the tab list nav buttons that would result in navigating to a blank page.