### PR TITLE
Notes: Always provide an entityId

### DIFF
--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -119,7 +119,11 @@ class ViewAgreement extends React.Component {
 
   static propTypes = {
     editLink: PropTypes.string,
-    match: PropTypes.object,
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
     mutator: PropTypes.object,
     onClose: PropTypes.func,
     onCloseEdit: PropTypes.func,
@@ -469,7 +473,7 @@ class ViewAgreement extends React.Component {
     const agreementLines = this.getAgreementLines();
     if (!agreement || agreementLines === undefined) return this.renderLoadingPane();
 
-    const { stripes } = this.props;
+    const { match, stripes } = this.props;
     const sectionProps = this.getSectionProps();
 
     return (
@@ -558,7 +562,7 @@ class ViewAgreement extends React.Component {
           domainName="agreements"
           entityName={agreement.name}
           entityType="agreement"
-          entityId={agreement.id}
+          entityId={match.params.id}
           pathToNoteCreate="/erm/notes/new"
           pathToNoteDetails="/erm/notes"
         />

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -148,6 +148,7 @@ class ViewAgreement extends React.Component {
       eresourcesAgreementLines: false,
       supplementaryInfo: false,
       associatedAgreements: false,
+      agreementNotes: false,
     }
   }
 
@@ -557,15 +558,18 @@ class ViewAgreement extends React.Component {
             open={this.state.sections.associatedAgreements}
             {...sectionProps}
           />
+          <NotesSmartAccordion
+            domainName="agreements"
+            entityName={agreement.name}
+            entityType="agreement"
+            entityId={match.params.id}
+            id="agreementNotes"
+            onToggle={this.handleSectionToggle}
+            open={this.state.sections.agreementNotes}
+            pathToNoteCreate="/erm/notes/new"
+            pathToNoteDetails="/erm/notes"
+          />
         </AccordionSet>
-        <NotesSmartAccordion
-          domainName="agreements"
-          entityName={agreement.name}
-          entityType="agreement"
-          entityId={match.params.id}
-          pathToNoteCreate="/erm/notes/new"
-          pathToNoteDetails="/erm/notes"
-        />
         {this.renderEditLayer()}
       </Pane>
     );


### PR DESCRIPTION
Notes attempts to fetch based on the `entityId`, and the failed `GET` call can crash the page from inside stripes-connect.