### PR TITLE
Bug Fixes

### DIFF
--- a/src/components/Agreements/ViewAgreement/Sections/Eresources.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Eresources.js
@@ -18,7 +18,7 @@ export default class Eresources extends React.Component {
 
   renderBadge = () => {
     const count = get(this.props.agreementLines, ['length']);
-    if (!count) return <Icon icon="spinner-ellipsis" width="10px" />;
+    if (count === undefined) return <Icon icon="spinner-ellipsis" width="10px" />;
 
     return <Badge data-test-agreement-lines-count={count}>{count}</Badge>;
   }

--- a/src/components/Agreements/ViewAgreement/Sections/Organizations.js
+++ b/src/components/Agreements/ViewAgreement/Sections/Organizations.js
@@ -25,7 +25,7 @@ export default class Organizations extends React.Component {
     }).isRequired,
     id: PropTypes.string,
     onToggle: PropTypes.func,
-    organizations: PropTypes.object,
+    organizations: PropTypes.arrayOf(PropTypes.object),
     open: PropTypes.bool,
   };
 

--- a/src/components/Agreements/ViewAgreement/ViewAgreement.js
+++ b/src/components/Agreements/ViewAgreement/ViewAgreement.js
@@ -477,8 +477,7 @@ class ViewAgreement extends React.Component {
     const width = (query.helper) ? '50%' : '60%';
     const key = (query.helper) ? 'smallPane' : 'largePane';
     const agreement = this.getAgreement();
-    const agreementLines = this.getAgreementLines();
-    if (!agreement || agreementLines === undefined) return this.renderLoadingPane();
+    if (!agreement || (agreement.id !== match.params.id)) return this.renderLoadingPane();
     const sectionProps = this.getSectionProps();
 
     return (

--- a/src/components/Basket/Basket.js
+++ b/src/components/Basket/Basket.js
@@ -53,6 +53,7 @@ class Basket extends React.Component {
         replace: PropTypes.func,
       }),
       query: PropTypes.shape({
+        replace: PropTypes.func,
         update: PropTypes.func,
       }),
     }),
@@ -121,13 +122,11 @@ class Basket extends React.Component {
     }));
   }
 
-  constructAddToBasketParam = () => {
-    const selectedItems = Object.entries(this.state.selectedItems)
+  getSelectedItems = () => {
+    return Object.entries(this.state.selectedItems)
       .filter(([_, selected]) => selected)
       .map(([itemId]) => this.props.resources.basket.findIndex(i => i.id === itemId))
       .join(',');
-
-    return `${ADD_FROM_BASKET_PARAM}=${selectedItems}`;
   }
 
   renderFirstMenu = () => {
@@ -154,7 +153,14 @@ class Basket extends React.Component {
         buttonStyle="primary"
         data-test-basket-create-agreement
         disabled={disabled}
-        to={disabled ? null : `/erm/agreements?layer=create&${this.constructAddToBasketParam()}`}
+        onClick={() => {
+          this.props.mutator.query.replace({
+            _path: '/erm/agreements',
+            layer: 'create',
+            addFromBasket: this.getSelectedItems(),
+            basket: null,
+          });
+        }}
       >
         <FormattedMessage id="ui-agreements.basket.createAgreement" />
       </Button>
@@ -226,7 +232,14 @@ class Basket extends React.Component {
           buttonStyle="primary"
           data-test-basket-add-to-agreement
           disabled={disabled}
-          to={disabled ? null : `/erm/agreements/view/${this.state.selectedAgreement}?layer=edit&${this.constructAddToBasketParam()}`}
+          onClick={() => {
+            this.props.mutator.query.replace({
+              _path: `/erm/agreements/view/${this.state.selectedAgreement}`,
+              layer: 'edit',
+              addFromBasket: this.getSelectedItems(),
+              basket: null,
+            });
+          }}
         >
           <FormattedMessage id="ui-agreements.basket.addToSelectedAgreement" />
         </Button>

--- a/test/ui-testing/basket.js
+++ b/test/ui-testing/basket.js
@@ -100,8 +100,8 @@ module.exports.test = (uiTestCtx) => {
       search: 's',
       agreementName: `Basketforged Agreement #${number}`,
       agreementStartDate: '2019-01-31',
-      agreementRenewalPriority: 'Definitely Renew',
-      agreementStatus: 'In Negotiation',
+      agreementRenewalPriority: 'Definitely renew',
+      agreementStatus: 'In negotiation',
     };
 
     this.timeout(Number(config.test_timeout));
@@ -185,6 +185,7 @@ module.exports.test = (uiTestCtx) => {
             .type('#edit-agreement-status', values.agreementStatus)
             .click('#clickable-createagreement')
             .wait('[data-test-agreement-info]')
+            .waitUntilNetworkIdle(2000)
             .then(done)
             .catch(done);
         });

--- a/test/ui-testing/orgs.js
+++ b/test/ui-testing/orgs.js
@@ -3,286 +3,285 @@
 const generateNumber = () => Math.round(Math.random() * 100000);
 
 const ORGS = [{
-    name: `Content Provider ${generateNumber()}`,
-    role: 'Content Provider',
-    toDelete: true,
+  name: `Content Provider ${generateNumber()}`,
+  role: 'Content Provider',
+  toDelete: true,
 }, {
-    name: `Vendor ${generateNumber()}`,
-    role: 'Vendor',
-    editedName: `Subscription Agent ${generateNumber()}`,
-    editedRole: 'Subscription Agent',
+  name: `Vendor ${generateNumber()}`,
+  role: 'Vendor',
+  editedName: `Subscription Agent ${generateNumber()}`,
+  editedRole: 'Subscription Agent',
 }];
 
 
 module.exports.test = (uiTestCtx) => {
-    const orgs = ORGS;
+  const orgs = ORGS;
 
-    describe(`ui-agreements: set orgs: "${orgs.map(o => o.name).join(', ')}"`, function test() {
-        const { config, helpers } = uiTestCtx;
-        const nightmare = new Nightmare(config.nightmare);
+  describe(`ui-agreements: set orgs: "${orgs.map(o => o.name).join(', ')}"`, function test() {
+    const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
 
-        this.timeout(Number(config.test_timeout));
+    this.timeout(Number(config.test_timeout));
 
-        const contentProvider = orgs.find(o => o.role === 'Content Provider');
-        const orgToEdit = orgs.find(o => o.editedName);
-        const orgToDelete = orgs.find(o => o.toDelete);
+    const orgToEdit = orgs.find(o => o.editedName);
+    const orgToDelete = orgs.find(o => o.toDelete);
 
-        describe('login > open agreements > create agreements > edit orgs > logout', () => {
-            before((done) => {
-                helpers.login(nightmare, config, done);
-            });
+    describe('login > open agreements > create agreements > edit orgs > logout', () => {
+      before((done) => {
+        helpers.login(nightmare, config, done);
+      });
 
-            after((done) => {
-                helpers.logout(nightmare, config, done);
-            });
+      after((done) => {
+        helpers.logout(nightmare, config, done);
+      });
 
-            it('should open agreements app', done => {
-                helpers.clickApp(nightmare, done, 'agreements');
-            });
+      it('should open agreements app', done => {
+        helpers.clickApp(nightmare, done, 'agreements');
+      });
 
 
-            it('should navigate to create agreements page', done => {
-                const name = `Orgs Agreement #${generateNumber()}`;
+      it('should navigate to create agreements page', done => {
+        const name = `Orgs Agreement #${generateNumber()}`;
 
-                console.log(`\tCreating ${name}`);
+        console.log(`\tCreating ${name}`);
 
-                nightmare
-                    .wait('#agreements-module-display')
-                    .click('nav #agreements')
-                    .wait('#clickable-newagreement')
-                    .click('#clickable-newagreement')
-                    .waitUntilNetworkIdle(1000)
-                    .wait('#accordion-toggle-button-agreementFormOrganizations')
-                    .click('#accordion-toggle-button-agreementFormOrganizations')
-                    .waitUntilNetworkIdle(1000)
-                    .wait('#edit-agreement-name')
-                    .insert('#edit-agreement-name', name)
-                    .click('#edit-agreement-start-date')
-                    .type('#edit-agreement-start-date', '\u000d') // "Enter" selects current date
-                    .insert('#edit-agreement-end-date', '2019-01-31')
-                    .insert('#edit-agreement-cancellation-deadline', '2019-01-15')
-                    .type('#edit-agreement-status', 'draft')
-                    .then(done)
-                    .catch(done);
-            });
+        nightmare
+          .wait('#agreements-module-display')
+          .click('nav #agreements')
+          .wait('#clickable-newagreement')
+          .click('#clickable-newagreement')
+          .waitUntilNetworkIdle(1000)
+          .wait('#accordion-toggle-button-agreementFormOrganizations')
+          .click('#accordion-toggle-button-agreementFormOrganizations')
+          .waitUntilNetworkIdle(1000)
+          .wait('#edit-agreement-name')
+          .insert('#edit-agreement-name', name)
+          .click('#edit-agreement-start-date')
+          .type('#edit-agreement-start-date', '\u000d') // "Enter" selects current date
+          .insert('#edit-agreement-end-date', '2019-01-31')
+          .insert('#edit-agreement-cancellation-deadline', '2019-01-15')
+          .type('#edit-agreement-status', 'draft')
+          .then(done)
+          .catch(done);
+      });
 
-            orgs.forEach((org, row) => {
-                it('should add org', done => {
-                    nightmare
-                        .click('#add-org-btn')
-                        .evaluate((r) => {
-                            if (!document.querySelector(`#orgs-nameOrg-${r}-search-button`)) {
-                                throw Error('Expected organization picker button to exist.');
-                            }
+      orgs.forEach((org, row) => {
+        it('should add org', done => {
+          nightmare
+            .click('#add-org-btn')
+            .evaluate((r) => {
+              if (!document.querySelector(`#orgs-nameOrg-${r}-search-button`)) {
+                throw Error('Expected organization picker button to exist.');
+              }
 
-                            if (!document.querySelector(`#orgs-role-${r}`)) {
-                                throw Error('Expected role dropdown to exist.');
-                            }
-                        }, row)
-                        .then(done)
-                        .catch(done);
-                });
-
-                it('should select org', done => {
-                    nightmare
-                        .click(`#orgs-nameOrg-${row}-search-button`)
-                        .wait('#clickable-filter-status-active')
-                        .click('#clickable-filter-status-active')
-                        .wait(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
-                        .click(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
-                        .waitUntilNetworkIdle(2000)
-                        .evaluate((r, _orgs) => {
-                            const orgElement = document.querySelector(`#orgs-nameOrg-${r}`);
-                            const name = orgElement.value;
-                            if (!name) {
-                                throw Error('Org field has no value!');
-                            }
-
-                            return name;
-                        }, row, orgs)
-                        .then(name => {
-                            orgs[row].name = name;
-                        })
-                        .then(done)
-                        .catch(done);
-                });
-
-                it(`should assign role: ${org.role}`, done => {
-                    nightmare
-                        .wait(`#orgs-role-${row}`)
-                        .click(`#orgs-role-${row}`)
-                        .type(`#orgs-role-${row}`, org.role)
-                        .evaluate((r, o) => {
-                            const roleElement = document.querySelector(`#orgs-role-${r}`);
-                            const role = roleElement.selectedOptions[0].textContent;
-                            if (role !== o.role) {
-                                throw Error(`Expected role to be ${o.role} but is ${role}`);
-                            }
-                        }, row, org)
-                        .then(done)
-                        .catch(done);
-                });
-            });
-
-            it('should create Agreement', done => {
-                nightmare
-                    .click('#clickable-createagreement')
-                    .waitUntilNetworkIdle(2000) // Wait for record to be fetched
-                    .then(done)
-                    .catch(done);
-            });
-
-            orgs.forEach(org => {
-                it(`should find "${org.name}" in Organizations list with role ${org.role}`, done => {
-                    nightmare
-                        .evaluate(o => {
-                            const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
-                            const row = rows.find(r => r.indexOf(o.name) >= 0);
-                            if (!row) {
-                                throw Error(`Could not find row with an org named ${o.name}`);
-                            }
-                            if (row.indexOf(o.role) < 0) {
-                                throw Error(`Expected row for "${o.name}" to contain role ${o.role}.`);
-                            }
-                        }, org)
-                        .then(done)
-                        .catch(done);
-                });
-            });
-
-            it('should open edit Agreement', done => {
-                nightmare
-                    .click('[class*=paneHeader] [class*=dropdown] button')
-                    .wait('#clickable-edit-agreement')
-                    .click('#clickable-edit-agreement')
-                    .wait('#accordion-toggle-button-agreementFormOrganizations')
-                    .click('#accordion-toggle-button-agreementFormOrganizations')
-                    .waitUntilNetworkIdle(1000)
-                    .then(done)
-                    .catch(done);
-            });
-
-            orgs.forEach((org, i) => {
-                it(`should find correctly loaded values for org ${i}`, done => {
-                    nightmare
-                        .evaluate(o => {
-                            const orgElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
-                            const orgElement = orgElements.find(e => e.value === o.name);
-                            if (!orgElement) {
-                                throw Error(`Failed to find org name picker with loaded org of ${o.name}`);
-                            }
-
-                            const roleElementId = orgElement.id.replace('nameOrg', 'role');
-                            const roleElement = document.getElementById(roleElementId);
-                            const roleValue = roleElement.selectedOptions[0].textContent;
-                            if (roleValue !== o.role) {
-                                throw Error(`Expected ${o.name}'s role to be ${o.role}. It is ${roleValue}.`);
-                            }
-                        }, org)
-                        .then(done)
-                        .catch(done);
-                });
-            });
-
-            if (orgToEdit) {
-                it('should edit Agreement', done => {
-                    nightmare
-                        .evaluate(o => {
-                            const nameElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
-                            const index = nameElements.findIndex(e => e.value === o.name);
-                            if (index === -1) {
-                                throw Error(`Failed to find org picker with loaded value of ${o.name}`);
-                            }
-
-                            return index;
-                        }, orgToEdit)
-                        .then(row => {
-                            return nightmare
-                                .click(`#orgs-nameOrg-${row}-search-button`)
-                                .wait('#clickable-filter-status-active')
-                                .click('#clickable-filter-status-active')
-                                .wait('#list-plugin-find-organization [aria-rowindex="10"] > a')
-                                .click('#list-plugin-find-organization [aria-rowindex="10"] > a')
-                                .waitUntilNetworkIdle(2000)
-                                .wait(`#orgs-role-${row}`)
-                                .click(`#orgs-role-${row}`)
-                                .type(`#orgs-role-${row}`, orgToEdit.editedRole)
-                                .evaluate((r, _orgs) => {
-                                    const orgElement = document.querySelector(`#orgs-nameOrg-${r}`);
-                                    const name = orgElement.value;
-                                    if (!name) {
-                                        throw Error('Org name field has no value!');
-                                    }
-
-                                    return name;
-                                }, row, orgs)
-                                .then(name => {
-                                    orgToEdit.editedName = name;
-                                });
-                        })
-                        .then(done)
-                        .catch(done);
-                });
-            }
-
-            if (orgToDelete) {
-                it('should delete org', done => {
-                    nightmare
-                        .evaluate(o => {
-                            const nameElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
-                            const index = nameElements.findIndex(e => e.value === o.name);
-                            if (index === -1) {
-                                throw Error(`Failed to find org picker with loaded user of ${o.name}`);
-                            }
-
-                            return index;
-                        }, orgToDelete)
-                        .then(row => nightmare.click(`#orgs-delete-${row}`))
-                        .then(done)
-                        .catch(done);
-                });
-            }
-
-            it('should save updated Agreement', done => {
-                nightmare
-                    .click('#clickable-updateagreement')
-                    .waitUntilNetworkIdle(2000) // Wait for record to be fetched
-                    .then(done)
-                    .catch(done);
-            });
-
-            if (orgToEdit) {
-                it(`should find org in Organizations list with role ${orgToEdit.editedRole}`, done => {
-                    nightmare
-                        .evaluate(o => {
-                            const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
-                            const row = rows.find(r => r.indexOf(o.editedName) >= 0);
-                            if (!row) {
-                                throw Error(`Could not find row with an org named ${o.editedName}`);
-                            }
-                            if (row.indexOf(o.editedRole) < 0) {
-                                throw Error(`Expected row for "${o.editedName}" to contain role ${o.editedRole}.`);
-                            }
-                        }, orgToEdit)
-                        .then(done)
-                        .catch(done);
-                });
-            }
-
-            if (orgToDelete) {
-                it(`should NOT find org in organizations list with role ${orgToDelete.role}`, done => {
-                    nightmare
-                        .evaluate(o => {
-                            const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
-                            const row = rows.find(r => r.indexOf(o.name) >= 0 && r.indexOf(o.role) >= 0);
-                            if (row) {
-                                throw Error(`Found a row with a org named ${o.name} when it should have been deleted.`);
-                            }
-                        }, orgToDelete)
-                        .then(done)
-                        .catch(done);
-                });
-            }
+              if (!document.querySelector(`#orgs-role-${r}`)) {
+                throw Error('Expected role dropdown to exist.');
+              }
+            }, row)
+            .then(done)
+            .catch(done);
         });
+
+        it('should select org', done => {
+          nightmare
+            .click(`#orgs-nameOrg-${row}-search-button`)
+            .wait('#clickable-filter-status-active')
+            .click('#clickable-filter-status-active')
+            .wait(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
+            .click(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
+            .waitUntilNetworkIdle(2000)
+            .evaluate((r, _orgs) => {
+              const orgElement = document.querySelector(`#orgs-nameOrg-${r}`);
+              const name = orgElement.value;
+              if (!name) {
+                throw Error('Org field has no value!');
+              }
+
+              return name;
+            }, row, orgs)
+            .then(name => {
+              orgs[row].name = name;
+            })
+            .then(done)
+            .catch(done);
+        });
+
+        it(`should assign role: ${org.role}`, done => {
+          nightmare
+            .wait(`#orgs-role-${row}`)
+            .click(`#orgs-role-${row}`)
+            .type(`#orgs-role-${row}`, org.role)
+            .evaluate((r, o) => {
+              const roleElement = document.querySelector(`#orgs-role-${r}`);
+              const role = roleElement.selectedOptions[0].textContent;
+              if (role !== o.role) {
+                throw Error(`Expected role to be ${o.role} but is ${role}`);
+              }
+            }, row, org)
+            .then(done)
+            .catch(done);
+        });
+      });
+
+      it('should create Agreement', done => {
+        nightmare
+          .click('#clickable-createagreement')
+          .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .then(done)
+          .catch(done);
+      });
+
+      orgs.forEach(org => {
+        it(`should find "${org.name}" in Organizations list with role ${org.role}`, done => {
+          nightmare
+            .evaluate(o => {
+              const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
+              const row = rows.find(r => r.indexOf(o.name) >= 0);
+              if (!row) {
+                throw Error(`Could not find row with an org named ${o.name}`);
+              }
+              if (row.indexOf(o.role) < 0) {
+                throw Error(`Expected row for "${o.name}" to contain role ${o.role}.`);
+              }
+            }, org)
+            .then(done)
+            .catch(done);
+        });
+      });
+
+      it('should open edit Agreement', done => {
+        nightmare
+          .click('[class*=paneHeader] [class*=dropdown] button')
+          .wait('#clickable-edit-agreement')
+          .click('#clickable-edit-agreement')
+          .wait('#accordion-toggle-button-agreementFormOrganizations')
+          .click('#accordion-toggle-button-agreementFormOrganizations')
+          .waitUntilNetworkIdle(1000)
+          .then(done)
+          .catch(done);
+      });
+
+      orgs.forEach((org, i) => {
+        it(`should find correctly loaded values for org ${i}`, done => {
+          nightmare
+            .evaluate(o => {
+              const orgElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
+              const orgElement = orgElements.find(e => e.value === o.name);
+              if (!orgElement) {
+                throw Error(`Failed to find org name picker with loaded org of ${o.name}`);
+              }
+
+              const roleElementId = orgElement.id.replace('nameOrg', 'role');
+              const roleElement = document.getElementById(roleElementId);
+              const roleValue = roleElement.selectedOptions[0].textContent;
+              if (roleValue !== o.role) {
+                throw Error(`Expected ${o.name}'s role to be ${o.role}. It is ${roleValue}.`);
+              }
+            }, org)
+            .then(done)
+            .catch(done);
+        });
+      });
+
+      if (orgToEdit) {
+        it('should edit Agreement', done => {
+          nightmare
+            .evaluate(o => {
+              const nameElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
+              const index = nameElements.findIndex(e => e.value === o.name);
+              if (index === -1) {
+                throw Error(`Failed to find org picker with loaded value of ${o.name}`);
+              }
+
+              return index;
+            }, orgToEdit)
+            .then(row => {
+              return nightmare
+                .click(`#orgs-nameOrg-${row}-search-button`)
+                .wait('#clickable-filter-status-active')
+                .click('#clickable-filter-status-active')
+                .wait('#list-plugin-find-organization [aria-rowindex="10"] > a')
+                .click('#list-plugin-find-organization [aria-rowindex="10"] > a')
+                .waitUntilNetworkIdle(2000)
+                .wait(`#orgs-role-${row}`)
+                .click(`#orgs-role-${row}`)
+                .type(`#orgs-role-${row}`, orgToEdit.editedRole)
+                .evaluate((r, _orgs) => {
+                  const orgElement = document.querySelector(`#orgs-nameOrg-${r}`);
+                  const name = orgElement.value;
+                  if (!name) {
+                    throw Error('Org name field has no value!');
+                  }
+
+                  return name;
+                }, row, orgs)
+                .then(name => {
+                  orgToEdit.editedName = name;
+                });
+            })
+            .then(done)
+            .catch(done);
+        });
+      }
+
+      if (orgToDelete) {
+        it('should delete org', done => {
+          nightmare
+            .evaluate(o => {
+              const nameElements = [...document.querySelectorAll('input[id^=orgs-nameOrg-]')];
+              const index = nameElements.findIndex(e => e.value === o.name);
+              if (index === -1) {
+                throw Error(`Failed to find org picker with loaded user of ${o.name}`);
+              }
+
+              return index;
+            }, orgToDelete)
+            .then(row => nightmare.click(`#orgs-delete-${row}`))
+            .then(done)
+            .catch(done);
+        });
+      }
+
+      it('should save updated Agreement', done => {
+        nightmare
+          .click('#clickable-updateagreement')
+          .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .then(done)
+          .catch(done);
+      });
+
+      if (orgToEdit) {
+        it(`should find org in Organizations list with role ${orgToEdit.editedRole}`, done => {
+          nightmare
+            .evaluate(o => {
+              const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
+              const row = rows.find(r => r.indexOf(o.editedName) >= 0);
+              if (!row) {
+                throw Error(`Could not find row with an org named ${o.editedName}`);
+              }
+              if (row.indexOf(o.editedRole) < 0) {
+                throw Error(`Expected row for "${o.editedName}" to contain role ${o.editedRole}.`);
+              }
+            }, orgToEdit)
+            .then(done)
+            .catch(done);
+        });
+      }
+
+      if (orgToDelete) {
+        it(`should NOT find org in organizations list with role ${orgToDelete.role}`, done => {
+          nightmare
+            .evaluate(o => {
+              const rows = [...document.querySelectorAll('[data-test-organizations-org]')].map(e => e.textContent);
+              const row = rows.find(r => r.indexOf(o.name) >= 0 && r.indexOf(o.role) >= 0);
+              if (row) {
+                throw Error(`Found a row with a org named ${o.name} when it should have been deleted.`);
+              }
+            }, orgToDelete)
+            .then(done)
+            .catch(done);
+        });
+      }
     });
+  });
 };


### PR DESCRIPTION
- Better View Agreement pane spinner rendering
  - Only render it when we don't have the agreement, not when we just lack the agreement lines.
- Smarter agreement line count rendering in its badge.
- Fixed issue where Create/Edit Agreement link from the Basket wouldn't hide the Basket layer. 
  - The interplay with query resources and the URL is janky, so I'm forced to just use the query resource directly here.
  - Normally, you'd expect that following a `Link` where the `basket` param is unset would...remove the `basket` param from the URL. But it doesn't do that...