### PR TITLE
ERM-276: Support date strings instead of datetime strings

### DIFF
--- a/src/components/AgreementSections/Header.js
+++ b/src/components/AgreementSections/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
@@ -9,6 +9,7 @@ import {
   Row,
 } from '@folio/stripes/components';
 
+import FormattedUTCDate from '../FormattedUTCDate';
 import css from './Header.css';
 
 export default class Header extends React.Component {
@@ -44,14 +45,14 @@ export default class Header extends React.Component {
         <Col xs={2}>
           <KeyValue label={<FormattedMessage id="ui-agreements.agreements.startDate" />}>
             <div data-test-agreement-start-date>
-              {startDate ? <FormattedDate value={startDate} /> : '-'}
+              {startDate ? <FormattedUTCDate value={startDate} /> : '-'}
             </div>
           </KeyValue>
         </Col>
         <Col xs={2}>
           <KeyValue label={<FormattedMessage id="ui-agreements.agreements.endDate" />}>
             <div data-test-agreement-end-date>
-              {endDate ? <FormattedDate value={endDate} /> : '-'}
+              {endDate ? <FormattedUTCDate value={endDate} /> : '-'}
             </div>
           </KeyValue>
         </Col>

--- a/src/components/AgreementSections/Info.js
+++ b/src/components/AgreementSections/Info.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import {
   Col,
   KeyValue,
   Row,
 } from '@folio/stripes/components';
+
+import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class Info extends React.Component {
   static propTypes = {
@@ -50,7 +52,7 @@ export default class Info extends React.Component {
           <Col xs={4}>
             <KeyValue label={<FormattedMessage id="ui-agreements.agreements.cancellationDeadline" />}>
               <div data-test-agreement-cancellation-deadline>
-                {agreement.cancellationDeadline ? <FormattedDate value={agreement.cancellationDeadline} /> : '-'}
+                {agreement.cancellationDeadline ? <FormattedUTCDate value={agreement.cancellationDeadline} /> : '-'}
               </div>
             </KeyValue>
           </Col>

--- a/src/components/AgreementSections/LinkedLicenses.js
+++ b/src/components/AgreementSections/LinkedLicenses.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Headline, Layout, KeyValue, MultiColumnList, InfoPopover } from '@folio/stripes/components';
 import { LicenseCard, LicenseEndDate } from '@folio/stripes-erm-components';
+
+import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class LinkedLicenses extends React.Component {
   static propTypes = {
@@ -74,7 +76,7 @@ export default class LinkedLicenses extends React.Component {
             note: link => (link.note ? <InfoPopover content={link.note} /> : ''),
             name: ({ remoteId_object: license = {} }) => license.name,
             status: link => (link.status ? link.status.label : '-'),
-            startDate: ({ remoteId_object: license = {} }) => (license.startDate ? <FormattedDate value={license.startDate} /> : '-'),
+            startDate: ({ remoteId_object: license = {} }) => (license.startDate ? <FormattedUTCDate value={license.startDate} /> : '-'),
             endDate: ({ remoteId_object: license = {} }) => <LicenseEndDate license={license} />,
           }}
           interactive={false}

--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage } from 'react-intl';
-
+import { FormattedMessage } from 'react-intl';
 import { Icon, Layout } from '@folio/stripes/components';
+
+import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class CoverageStatements extends React.Component {
   static propTypes = {
@@ -45,7 +46,7 @@ export default class CoverageStatements extends React.Component {
 
     return (
       <React.Fragment>
-        { date ? <div data-test-date={date}><FormattedDate value={date} /></div> : null }
+        { date ? <div data-test-date={date}><FormattedUTCDate value={date} /></div> : null }
         <div
           data-test-issue={issue}
           data-test-volume={volume}

--- a/src/components/EResourceSections/Agreements.js
+++ b/src/components/EResourceSections/Agreements.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { Link } from 'react-router-dom';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { Badge, Headline, MultiColumnList } from '@folio/stripes/components';
 import { Spinner } from '@folio/stripes-erm-components';
@@ -11,6 +11,7 @@ import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';
 import EResourceLink from '../EResourceLink';
 import EResourceType from '../EResourceType';
+import FormattedUTCDate from '../FormattedUTCDate';
 import { getResourceFromEntitlement, urls } from '../utilities';
 
 export default class Agreements extends React.Component {
@@ -32,8 +33,8 @@ export default class Agreements extends React.Component {
         formatter={{
           name: ({ owner }) => <Link to={urls.agreementView(owner.id)}>{owner.name}</Link>,
           type: ({ owner }) => get(owner, 'agreementStatus.label', ''),
-          startDate: ({ owner }) => owner.startDate && <FormattedDate value={owner.startDate} />,
-          endDate: ({ owner }) => owner.endDate && <FormattedDate value={owner.endDate} />,
+          startDate: ({ owner }) => owner.startDate && <FormattedUTCDate value={owner.startDate} />,
+          endDate: ({ owner }) => owner.endDate && <FormattedUTCDate value={owner.endDate} />,
           package: (line) => <EResourceLink eresource={getResourceFromEntitlement(line)} />,
           acqMethod: ({ resource }) => <EResourceType resource={resource} />,
           coverage: line => <CoverageStatements statements={line.coverage} />,

--- a/src/components/FormattedUTCDate/FormattedUTCDate.js
+++ b/src/components/FormattedUTCDate/FormattedUTCDate.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { FormattedDate } from 'react-intl';
+
+export default function FormattedUTCDate(props) {
+  return <FormattedDate timeZone="UTC" {...props} />;
+}

--- a/src/components/FormattedUTCDate/index.js
+++ b/src/components/FormattedUTCDate/index.js
@@ -1,0 +1,1 @@
+export { default } from './FormattedUTCDate';

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import { get, noop } from 'lodash';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   MultiColumnList,
@@ -24,6 +24,7 @@ import {
 } from '@folio/stripes/smart-components';
 
 import AgreementFilters from '../AgreementFilters';
+import FormattedUTCDate from '../FormattedUTCDate';
 import IfEResourcesEnabled from '../IfEResourcesEnabled';
 import { urls } from '../utilities';
 import css from './Agreements.css';
@@ -89,9 +90,9 @@ export default class Agreements extends React.Component {
 
   formatter = {
     agreementStatus: a => get(a, 'agreementStatus.label'),
-    startDate: a => a.startDate && <FormattedDate value={a.startDate} />,
-    endDate: a => a.endDate && <FormattedDate value={a.endDate} />,
-    cancellationDeadline: a => a.cancellationDeadline && <FormattedDate value={a.cancellationDeadline} />,
+    startDate: a => a.startDate && <FormattedUTCDate value={a.startDate} />,
+    endDate: a => a.endDate && <FormattedUTCDate value={a.endDate} />,
+    cancellationDeadline: a => a.cancellationDeadline && <FormattedUTCDate value={a.cancellationDeadline} />,
   }
 
   rowFormatter = (row) => {

--- a/src/components/views/Basket.js
+++ b/src/components/views/Basket.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import {
   Button,
@@ -15,6 +15,7 @@ import {
 } from '@folio/stripes/components';
 
 import BasketList from '../BasketList';
+import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class Basket extends React.Component {
   static propTypes = {
@@ -159,7 +160,7 @@ export default class Basket extends React.Component {
                     >
                       <Headline bold>{option.name}&nbsp;&#40;{option.agreementStatus.label}&#41;</Headline>{/* eslint-disable-line */}
                       <div>
-                        <strong><FormattedMessage id="ui-agreements.agreements.startDate" />: </strong><FormattedDate value={option.startDate} /> {/* eslint-disable-line */}
+                        <strong><FormattedMessage id="ui-agreements.agreements.startDate" />: </strong><FormattedUTCDate value={option.startDate} /> {/* eslint-disable-line */}
                       </div>
                     </div>
                   )}


### PR DESCRIPTION
mod-agreements is only responding with date strings as of https://github.com/folio-org/mod-agreements/pull/144 and https://github.com/folio-org/mod-agreements/pull/145

This means that when we pump a date like `2019-07-01` into react-intl's `FormattedDate`, it interprets that as `2019-07-01T00:00:00Z`. As part of the formatting, it translates it according to the tenant's time zone. As a result, any `-`-offset timezone from UTC will actually render that date as something like `6/30/2019` and not `7/1/2019`. This is a problem.

To get around this, we can pass `timeZone="UTC"`, [one of the DateTimeFormatOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat#Parameters), into `FormattedDate`.

And rather than passing in that prop every single time we use `FormattedDate`, I created a new `FormattedUTCDate` component to simplify the process.