### PR TITLE
Quote id of resourceId when searching for it

### DIFF
--- a/test/ui-testing/agreement-crud.js
+++ b/test/ui-testing/agreement-crud.js
@@ -42,7 +42,7 @@ const createAgreement = (nightmare, done, defaultValues, resourceId) => {
       .click('#accordion-toggle-button-formLines')
       .click('#add-agreement-line-button')
       .click('#basket-selector')
-      .click(`[id*=${resourceId}]`)
+      .click(`[id*="${resourceId}"]`)
       .click('#basket-selector-add-button')
       .wait(1000);
   }


### PR DESCRIPTION
Attribute selectors need to have their values quoted.