### PR TITLE
ERM-288: Set dataKey for find-license plugin

### DIFF
--- a/src/components/LicensesFieldArray/LicenseLookup.js
+++ b/src/components/LicensesFieldArray/LicenseLookup.js
@@ -29,6 +29,7 @@ export default class LicenseLookup extends React.Component {
     return (
       <span>
         <Pluggable
+          dataKey={id}
           type="find-license"
           onLicenseSelected={onSelectLicense}
           renderTrigger={(props) => (

--- a/test/ui-testing/license-terms.js
+++ b/test/ui-testing/license-terms.js
@@ -52,8 +52,6 @@ module.exports.test = (uiTestCtx) => {
             .insert('#edit-license-name', l.name)
             .insert('#edit-license-start-date', l.startDate)
 
-            .click('#accordion-toggle-button-licenseFormTerms')
-
             .then(done)
             .catch(done);
         });


### PR DESCRIPTION
Without setting a unique `dataKey`, the plugin reuses the resources for previous uses of it. This ensures it uses the default filters/queries each load.