### PR TITLE
ERM-374: Support Orders interface 7.0

### DIFF
--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -56,7 +56,7 @@ class AgreementEditRoute extends React.Component {
 
         return query ? { query } : null;
       },
-      fetch: props => !!props.stripes.hasInterface('orders', '6.0'),
+      fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0'),
       records: 'poLines',
     },
     orgRoleValues: {

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -65,7 +65,7 @@ class AgreementViewRoute extends React.Component {
 
         return query ? { query } : null;
       },
-      fetch: props => !!props.stripes.hasInterface('orders', '6.0'),
+      fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0'),
       records: 'poLines',
     },
     terms: {


### PR DESCRIPTION
Fetching PO Lines no longer occurs because a new Orders interface version of 7.0 is out. The `okapiInterfaces` has been updated but the `fetch` conditionals need to be as well.