### PR TITLE
Remove unused method

### DIFF
--- a/src/components/UsageDataProvidersFieldArray/UsageDataProviderField.js
+++ b/src/components/UsageDataProvidersFieldArray/UsageDataProviderField.js
@@ -32,12 +32,6 @@ export default class UsageDataProviderField extends React.Component {
     udp: {},
   }
 
-  renderEmpty = () => (
-    <Layout className="padding-bottom-gutter" data-test-udp-empty-message>
-      <FormattedMessage id="ui-agreements.usageData.agreementHasNone" />
-    </Layout>
-  );
-
   renderLinkUDPButton = () => (
     <Pluggable
       aria-haspopup="true"


### PR DESCRIPTION
There's another `renderEmpty` below this one - that's the one we're using.