### PR TITLE
ERM-309: Render internal contacts as cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0 IN PROGRESS
 * Allow only one Vendor organization to be selected.
+* Render Internal Contacts as cards. ERM-309
 
 ## 3.0.0 2019-07-23
 * Support Orders interface 7.0. ERM-350

--- a/src/components/AgreementLinesFieldArray/POLineField.js
+++ b/src/components/AgreementLinesFieldArray/POLineField.js
@@ -14,6 +14,7 @@ export default class POLineField extends React.Component {
     }).isRequired,
     poLine: PropTypes.shape({
       acquisitionMethod: PropTypes.string,
+      id: PropTypes.string,
       poLineNumber: PropTypes.string,
       title: PropTypes.string,
     }),

--- a/src/components/AgreementSections/InternalContacts.js
+++ b/src/components/AgreementSections/InternalContacts.js
@@ -11,19 +11,7 @@ export default class InternalContacts extends React.Component {
     agreement: PropTypes.shape({
       contacts: PropTypes.arrayOf(
         PropTypes.shape({
-          role: PropTypes.shape({
-            label: PropTypes.string,
-          }),
-          user: PropTypes.oneOfType([
-            PropTypes.shape({
-              personal: PropTypes.shape({
-                firstName: PropTypes.string,
-                middleName: PropTypes.string,
-                lastName: PropTypes.string,
-              }).isRequired,
-            }).isRequired,
-            PropTypes.string
-          ]),
+          id: PropTypes.string,
         })
       ),
     }).isRequired,

--- a/src/components/AgreementSections/InternalContacts.js
+++ b/src/components/AgreementSections/InternalContacts.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 
 import { Accordion, Badge } from '@folio/stripes/components';
+import { InternalContactCard } from '@folio/stripes-erm-components';
 
 export default class InternalContacts extends React.Component {
   static propTypes = {
@@ -42,29 +42,12 @@ export default class InternalContacts extends React.Component {
 
     if (!contacts.length) return <FormattedMessage id="ui-agreements.contacts.noContacts" />;
 
-    return contacts.map((contact, i) => {
-      if (!contact.user) return null;
-
-      const firstName = get(contact, 'user.personal.firstName');
-      const lastName = get(contact, 'user.personal.lastName');
-      const middleName = get(contact, 'user.personal.middleName');
-      let displayName = lastName;
-      if (firstName) displayName = `${displayName}, ${firstName}`;
-      if (middleName) displayName = `${displayName} ${middleName}`;
-
-      const role = get(contact, 'role.label', '');
-
-      return (
-        <div
-          data-test-agreement-contact
-          key={`${contact.user.id}-${i}`}
-        >
-          <Link to={`/users/view/${contact.user.id}`}>{displayName}</Link>
-          ,&nbsp;
-          <span>{role}</span>
-        </div>
-      );
-    });
+    return contacts.map(contact => (
+      <InternalContactCard
+        contact={contact}
+        key={contact.id}
+      />
+    ));
   }
 
   render() {


### PR DESCRIPTION
Using the new `InternalCardComponent` introduced in https://github.com/folio-org/stripes-erm-components/pull/102