### PR TITLE
Added support for mod-orgs-storage 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.0 IN PROGRESS
 * Allow only one Vendor organization to be selected.
 * Render Internal Contacts as cards. ERM-309
+* Added support for `mod-organizations-storage` 2.0
 
 ## 3.0.0 2019-07-23
 * Support Orders interface 7.0. ERM-350

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
       "invoice": "1.0",
       "licenses": "1.0",
       "orders": "6.0 7.0",
+      "organizations-storage.interfaces": "2.0",
       "users": "13.0 14.0 15.0"
     },
     "permissionSets": [

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -51,7 +51,7 @@ class AgreementViewRoute extends React.Component {
 
         return query ? { query } : null;
       },
-      fetch: props => !!props.stripes.hasInterface('organizations-storage.interfaces', '1.0'),
+      fetch: props => !!props.stripes.hasInterface('organizations-storage.interfaces', '1.0 2.0'),
       records: 'interfaces',
     },
     orderLines: {


### PR DESCRIPTION
Now listing `organizations-storage.interfaces` in `okapiInterfaces` so that a major version can't be pushed to a platform without us knowing.