### PR TITLE
Fixed tests

### DIFF
--- a/test/ui-testing/docs.js
+++ b/test/ui-testing/docs.js
@@ -68,7 +68,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-create-agreement')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
-          .click('#accordion-toggle-button-licenses')
+          .click('#clickable-expand-all')
           .then(done)
           .catch(done);
       });
@@ -239,7 +239,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-update-agreement')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
-          .click('#accordion-toggle-button-licenses')
+          .click('#clickable-expand-all')
           .then(done)
           .catch(done);
       });

--- a/test/ui-testing/docs.js
+++ b/test/ui-testing/docs.js
@@ -68,6 +68,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-create-agreement')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .click('#accordion-toggle-button-licenses')
           .then(done)
           .catch(done);
       });
@@ -80,7 +81,7 @@ module.exports.test = (uiTestCtx,
               if (!docCard) {
                 throw Error(`Could not find doc card with a doc named ${d.name}`);
               }
-              const name = docCard.querySelector('[data-test-doc-name]').innerText;
+              const name = docCard.querySelector('[data-test-doc-name]').innerText.trim();
               if (name !== d.name) {
                 throw Error(`Expected name to be ${d.name} and found ${name}.`);
               }
@@ -238,6 +239,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-update-agreement')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .click('#accordion-toggle-button-licenses')
           .then(done)
           .catch(done);
       });
@@ -250,7 +252,7 @@ module.exports.test = (uiTestCtx,
               if (!docCard) {
                 throw Error(`Could not find doc card with a doc named ${d.name}`);
               }
-              const name = docCard.querySelector('[data-test-doc-name]').innerText;
+              const name = docCard.querySelector('[data-test-doc-name]').innerText.trim();
               if (name !== d.name) {
                 throw Error(`Expected name to be ${d.name} and found ${name}.`);
               }

--- a/test/ui-testing/orgs.js
+++ b/test/ui-testing/orgs.js
@@ -82,8 +82,6 @@ module.exports.test = (uiTestCtx) => {
         it('should select org', done => {
           nightmare
             .click(`#orgs-nameOrg-${row}-search-button`)
-            .wait('#clickable-filter-status-active')
-            .click('#clickable-filter-status-active')
             .wait(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
             .click(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
             .waitUntilNetworkIdle(2000)
@@ -194,8 +192,6 @@ module.exports.test = (uiTestCtx) => {
                 .click(`#orgs-unlink-${row}`)
                 .wait(`#orgs-nameOrg-${row}-search-button`)
                 .click(`#orgs-nameOrg-${row}-search-button`)
-                .wait('#clickable-filter-status-active')
-                .click('#clickable-filter-status-active')
                 .wait('#list-plugin-find-organization [aria-rowindex="12"] > a')
                 .click('#list-plugin-find-organization [aria-rowindex="12"] > a')
                 .waitUntilNetworkIdle(2000)


### PR DESCRIPTION
- Orgs changed their default filter values
  - Stopped checking the 'Active' checkbox
- Accordion rendering got tweaked somehow so that the document elements were present but were not being filled with data.
  - Expanded all accordions before `evaluate`ing 