### PR TITLE
ERM-409: Fixed truncated package contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-agreements
 
+## 3.2 IN PROGRESS
+* Fixed package content lists being truncated at 1000 entries. ERM-409
+
 ## 3.1.1 2019-08-21
 * Use locally-defined saveAndClose translation key.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/agreements",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "ERM agreement functionality for Stripes",
   "main": "src/index.js",
   "publishConfig": {


### PR DESCRIPTION
- We could write these MCLs with `virtualize` and
  `onNeedMoreData` props but I think it might be
  too heavy-handed and also hurts the scrollability
  and discoverability of the list.
- We can revisit this if this proves a horrible idea.