### PR TITLE
ERM-426: Fixed reset-query-term bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2 IN PROGRESS
 * Fixed package content lists being truncated at 1000 entries. ERM-409
 * Fixed bug where not all the agreement lines were being fetched.
+* Fixed bug where resetting query term wouldn't execute a search. ERM-426
 
 ## 3.1.1 2019-08-21
 * Use locally-defined saveAndClose translation key.

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -294,11 +294,7 @@ export default class Agreements extends React.Component {
                                 marginBottom0
                                 name="query"
                                 onChange={getSearchHandlers().query}
-                                onClear={() => {
-                                  getSearchHandlers().clear();
-                                  // TODO: Add way to trigger search automatically
-                                  // onSubmitSearch();
-                                }}
+                                onClear={getSearchHandlers().reset}
                                 value={searchValue.query}
                               />
                             )}

--- a/src/components/views/EResources.js
+++ b/src/components/views/EResources.js
@@ -255,11 +255,7 @@ export default class EResources extends React.Component {
                                 marginBottom0
                                 name="query"
                                 onChange={getSearchHandlers().query}
-                                onClear={() => {
-                                  getSearchHandlers().clear();
-                                  // TODO: Add way to trigger search automatically
-                                  // onSubmitSearch();
-                                }}
+                                onClear={getSearchHandlers().reset}
                                 value={searchValue.query}
                               />
                             )}

--- a/src/routes/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute.js
@@ -121,20 +121,8 @@ class AgreementsRoute extends React.Component {
     }
   }
 
-  querySetter = ({ nsValues, state }) => {
-    const defaults = {
-      filters: null,
-      query: null,
-      sort: null,
-    };
-
-    if (/reset/.test(state.changeType)) {
-      // A mutator's `replace()` function doesn't update the URL of the page. As a result,
-      // we always use `update()` but fully specify the values we want to null out.
-      this.props.mutator.query.update({ ...defaults, ...nsValues });
-    } else {
-      this.props.mutator.query.update(nsValues);
-    }
+  querySetter = ({ nsValues }) => {
+    this.props.mutator.query.update(nsValues);
   }
 
   queryGetter = () => {

--- a/src/routes/EResourcesRoute.js
+++ b/src/routes/EResourcesRoute.js
@@ -108,20 +108,8 @@ class EResourcesRoute extends React.Component {
     }
   }
 
-  querySetter = ({ nsValues, state }) => {
-    const defaults = {
-      filters: null,
-      query: null,
-      sort: null,
-    };
-
-    if (/reset/.test(state.changeType)) {
-      // A mutator's `replace()` function doesn't update the URL of the page. As a result,
-      // we always use `update()` but fully specify the values we want to null out.
-      this.props.mutator.query.update({ ...defaults, ...nsValues });
-    } else {
-      this.props.mutator.query.update(nsValues);
-    }
+  querySetter = ({ nsValues }) => {
+    this.props.mutator.query.update(nsValues);
   }
 
   queryGetter = () => {


### PR DESCRIPTION
Clicking the `X` button inside the query search text field wasn't executing a search. This was a TODO for a while during the refactor of SASQ. 

SASQ now provides `getSearchHandlers().reset` which is exactly what we want to reset the search term **and** perform a search.

However, this conflicted with our previous implementation of `querySetter` because the `changeType` is `search.reset`, which means that our querySetter will reset _all_ the fields.

In the meantime though, SASQ and our usage of it has changed so that we actually get values for filters, sort _and_ query for a `reset.all` changeType, so we don't have to mix-in the null values we previously did. Thus, we can simplify the whole thing to just a single line.

`7 additions and 38 deletions.` 😎