### PR TITLE
EResource Agreements: support paging

### DIFF
--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -26,9 +26,13 @@ class EResourceViewRoute extends React.Component {
     entitlements: {
       type: 'okapi',
       path: 'erm/resource/:{id}/entitlements',
+      records: 'results',
       perRequest: RECORDS_PER_REQUEST,
       recordsRequired: '%{entitlementsCount}',
       limitParam: 'perPage',
+      params: {
+        stats: 'true',
+      },
     },
     packageContents: {
       type: 'okapi',


### PR DESCRIPTION
Was missing a couple of these params. _Hopefully_, we'll literally never use this functionality because it means a library has _over a hundred agreements_ for a single eresource which would be....weird...but I guess theoretically possible once you factor in trial/expired/cancelled agreements...?