### PR TITLE
ERM-501: Fixed error messages for date fields

### DIFF
--- a/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
+++ b/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
@@ -14,6 +14,13 @@ import {
 import { composeValidators, EditCard, withKiwtFieldArray } from '@folio/stripes-erm-components';
 import { validators } from '../utilities';
 
+const multipleOpenEndedCoverages = (...rest) => (
+  validators.multipleOpenEnded(...rest, 'ui-agreements.errors.multipleOpenEndedCoverages')
+);
+
+const overlappingCoverages = (...rest) => (
+  validators.overlappingDates(...rest, 'ui-agreements.errors.overlappingCoverage')
+);
 class CustomCoverageFieldArray extends React.Component {
   static propTypes = {
     items: PropTypes.arrayOf(PropTypes.object),
@@ -46,8 +53,8 @@ class CustomCoverageFieldArray extends React.Component {
                 validate={composeValidators(
                   validators.requiredStartDate,
                   validators.dateOrder,
-                  validators.multipleOpenEnded,
-                  validators.overlappingDates,
+                  multipleOpenEndedCoverages,
+                  overlappingCoverages,
                 )}
               />
             </Col>
@@ -79,8 +86,8 @@ class CustomCoverageFieldArray extends React.Component {
                 name={`${name}[${index}].endDate`}
                 validate={composeValidators(
                   validators.dateOrder,
-                  validators.multipleOpenEnded,
-                  validators.overlappingDates,
+                  multipleOpenEndedCoverages,
+                  overlappingCoverages,
                 )}
               />
             </Col>

--- a/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
+++ b/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
@@ -21,6 +21,7 @@ const multipleOpenEndedCoverages = (...rest) => (
 const overlappingCoverages = (...rest) => (
   validators.overlappingDates(...rest, 'ui-agreements.errors.overlappingCoverage')
 );
+
 class CustomCoverageFieldArray extends React.Component {
   static propTypes = {
     items: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/AgreementPeriodsFieldArray/AgreementPeriodsFieldArray.js
+++ b/src/components/AgreementPeriodsFieldArray/AgreementPeriodsFieldArray.js
@@ -15,6 +15,14 @@ import {
 import { composeValidators, EditCard, withKiwtFieldArray } from '@folio/stripes-erm-components';
 import { validators } from '../utilities';
 
+const multipleOpenEndedPeriods = (...rest) => (
+  validators.multipleOpenEnded(...rest, 'ui-agreements.errors.multipleOpenEndedPeriods')
+);
+
+const overlappingPeriods = (...rest) => (
+  validators.overlappingDates(...rest, 'ui-agreements.errors.overlappingPeriod')
+);
+
 class AgreementPeriodsFieldArray extends React.Component {
   static propTypes = {
     items: PropTypes.arrayOf(PropTypes.object),
@@ -51,7 +59,7 @@ class AgreementPeriodsFieldArray extends React.Component {
                 validate={composeValidators(
                   validators.requiredStartDate,
                   validators.dateOrder,
-                  validators.overlappingDates,
+                  overlappingPeriods,
                 )}
               />
             </Col>
@@ -65,8 +73,8 @@ class AgreementPeriodsFieldArray extends React.Component {
                 name={`${name}[${index}].endDate`}
                 validate={composeValidators(
                   validators.dateOrder,
-                  validators.multipleOpenEnded,
-                  validators.overlappingDates,
+                  multipleOpenEndedPeriods,
+                  overlappingPeriods,
                 )}
               />
             </Col>

--- a/src/components/utilities/validators.js
+++ b/src/components/utilities/validators.js
@@ -43,19 +43,19 @@ const dateOrder = (value, allValues, meta) => {
   return undefined;
 };
 
-const multipleOpenEnded = (_value, allValues, meta) => {
+const multipleOpenEnded = (_value, allValues, meta, errorMessageKey) => {
   if (meta) {
-    // Name is something like "items[3].coverage[2].endDate" and we want the "items[3].coverage" array
-    const coverages = get(allValues, meta.name.substring(0, meta.name.lastIndexOf('[')), []);
-    let openEndedCoverages = 0;
-    coverages.forEach(c => {
-      if (c.startDate && !c.endDate) openEndedCoverages += 1;
+    // Name is something like "items[3].date[2].endDate" and we want the "items[3].date" array
+    const dates = get(allValues, meta.name.substring(0, meta.name.lastIndexOf('[')), []);
+    let openEndedDates = 0;
+    dates.forEach(c => {
+      if (c.startDate && !c.endDate) openEndedDates += 1;
     });
 
-    if (openEndedCoverages > 1) {
+    if (openEndedDates > 1) {
       return (
         <div data-test-error-multiple-open-ended>
-          <FormattedMessage id="ui-agreements.errors.multipleOpenEndedCoverages" />
+          <FormattedMessage id={errorMessageKey} />
         </div>
       );
     }
@@ -64,13 +64,13 @@ const multipleOpenEnded = (_value, allValues, meta) => {
   return undefined;
 };
 
-const overlappingDates = (value, allValues, meta) => {
+const overlappingDates = (value, allValues, meta, errorMessageKey) => {
   if (meta) {
-    // Name is something like "items[3].coverage[2].endDate" and we want the "items[3].coverage" array
-    const coverages = get(allValues, meta.name.substring(0, meta.name.lastIndexOf('[')), []);
-    const ranges = coverages
+    // Name is something like "items[3].date[2].endDate" and we want the "items[3].date" array
+    const dates = get(allValues, meta.name.substring(0, meta.name.lastIndexOf('[')), []);
+    const ranges = dates
       .map((c, i) => ({
-        coverageIndex: i,
+        dateIndex: i,
         startDate: new Date(c.startDate),
         endDate: c.endDate ? new Date(c.endDate) : new Date('4000-01-01'),
       }))
@@ -86,7 +86,7 @@ const overlappingDates = (value, allValues, meta) => {
 
         if (overlap) {
           accumulator.overlap = true;
-          accumulator.ranges.push([current.coverageIndex, previous.coverageIndex]);
+          accumulator.ranges.push([current.dateIndex, previous.dateIndex]);
         }
 
         return accumulator;
@@ -96,10 +96,10 @@ const overlappingDates = (value, allValues, meta) => {
 
     if (result.overlap) {
       return (
-        <div data-test-error-overlapping-coverage-dates>
+        <div data-test-error-overlapping-dates>
           <FormattedMessage
-            id="ui-agreements.errors.overlappingCoverage"
-            values={{ coverages: result.ranges.map(r => `${r[0] + 1} & ${r[1] + 1}`).join(', ') }}
+            id={errorMessageKey}
+            values={{ fields: result.ranges.map(r => `${r[0] + 1} & ${r[1] + 1}`).join(', ') }}
           />
         </div>
       );

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -173,8 +173,8 @@
   "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
   "errors.multipleOpenEndedCoverages": "Cannot have multiple open-ended coverage statements.",
   "errors.multipleOpenEndedPeriods": "Cannot have multiple open-ended agreement periods.",
-  "errors.overlappingCoverage": "The following coverages have overlapping dates: {coverages}",
-  "errors.overlappingPeriod": "The following periods have overlapping dates: {periods}",
+  "errors.overlappingCoverage": "The following coverages have overlapping dates: {fields}",
+  "errors.overlappingPeriod": "The following periods have overlapping dates: {fields}",
   "errors.undefinedUDP": "A Usage Data Provider must be selected.",
   "errors.unsetAgreementLines": "Select a resource and create this line, or delete it to continue.",
 

--- a/translations/ui-agreements/en_US.json
+++ b/translations/ui-agreements/en_US.json
@@ -137,7 +137,7 @@
     "agreementLines.customCoverageTitle": "Custom coverage #{number}",
     "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
     "errors.multipleOpenEndedCoverages": "Cannot have multiple open-ended coverage statements.",
-    "errors.overlappingCoverage": "The following coverages have overlapping dates: {coverages}",
+    "errors.overlappingCoverage": "The following coverages have overlapping dates: {fields}",
     "identifier.doi": "DOI",
     "identifier.eissn": "ISSN (Online)",
     "identifier.ezb": "EZB",
@@ -252,7 +252,7 @@
     "agreementPeriods.periodStart": "Period start",
     "agreementPeriods.periodTitle": "Agreement period #{number}",
     "errors.multipleOpenEndedPeriods": "Cannot have multiple open-ended agreement periods.",
-    "errors.overlappingPeriod": "The following periods have overlapping dates: {periods}",
+    "errors.overlappingPeriod": "The following periods have overlapping dates: {fields}",
     "agreements.reasonForClosure": "Reason for closure",
     "warn.clearReasonForClosure": "This reason will be cleared as status is not closed"
 }


### PR DESCRIPTION
Generalising the validators also resulted in reusing the same error messages...whoops! This keeps the logic general but allows the message to be specified external to the method.