### PR TITLE
ERM-522: alphasort tags in SAS filter

### DIFF
--- a/src/components/views/EResources.js
+++ b/src/components/views/EResources.js
@@ -36,7 +36,6 @@ export default class EResources extends React.Component {
     contentRef: PropTypes.object,
     data: PropTypes.shape({
       eresources: PropTypes.array.isRequired,
-      tags: PropTypes.array.isRequired,
     }),
     disableRecordCreation: PropTypes.bool,
     onNeedMoreData: PropTypes.func.isRequired,

--- a/src/routes/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute.js
@@ -60,7 +60,11 @@ class AgreementsRoute extends React.Component {
     },
     tagsValues: {
       type: 'okapi',
-      path: 'tags?limit=100',
+      path: 'tags',
+      params: {
+        limit: '1000',
+        query: 'cql.allRecords=1 sortby label',
+      },
       records: 'tags',
     },
     basket: { initialValue: [] },

--- a/src/routes/EResourcesRoute.js
+++ b/src/routes/EResourcesRoute.js
@@ -47,11 +47,6 @@ class EResourcesRoute extends React.Component {
       perRequest: 100,
       limitParam: 'perPage',
     },
-    tagsValues: {
-      type: 'okapi',
-      path: 'tags?limit=100',
-      records: 'tags',
-    },
     query: { initialValue: {} },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
   });
@@ -143,7 +138,6 @@ class EResourcesRoute extends React.Component {
         data={{
           eresources: get(resources, 'eresources.records', []),
           sourceValues: get(resources, 'sourceValues.records', []),
-          tags: get(resources, 'tags.records', []),
           typeValues: get(resources, 'typeValues.records', []),
         }}
         selectedRecordId={match.params.id}


### PR DESCRIPTION
- Sort tags via the CQL.
- Realised we don't use tags in eresources so pulled that query out.