### PR TITLE
Autofocus "Add (resource)" button on creation

### DIFF
--- a/src/components/LicensesFieldArray/LicenseField.js
+++ b/src/components/LicensesFieldArray/LicenseField.js
@@ -32,6 +32,18 @@ export default class LicenseField extends React.Component {
     license: {},
   }
 
+  constructor(props) {
+    super(props);
+
+    this.findLicenseButtonRef = React.createRef();
+  }
+
+  componentDidMount() {
+    if (!this.props.input.value) {
+      this.findLicenseButtonRef.current.focus();
+    }
+  }
+
   renderLinkLicenseButton = () => {
     const { id, onLicenseSelected } = this.props;
 
@@ -43,6 +55,7 @@ export default class LicenseField extends React.Component {
         renderTrigger={(props) => (
           <Button
             buttonStyle="primary"
+            buttonRef={this.findLicenseButtonRef}
             id={`${id}-find-license-btn`}
             onClick={props.onClick}
           >

--- a/src/components/LicensesFieldArray/LicenseField.js
+++ b/src/components/LicensesFieldArray/LicenseField.js
@@ -39,7 +39,7 @@ export default class LicenseField extends React.Component {
   }
 
   componentDidMount() {
-    if (!this.props.input.value) {
+    if (!this.props.input.value && this.findLicenseButtonRef.current) {
       this.findLicenseButtonRef.current.focus();
     }
   }

--- a/src/components/RelatedAgreementsFieldArray/RelatedAgreementField.js
+++ b/src/components/RelatedAgreementsFieldArray/RelatedAgreementField.js
@@ -46,7 +46,7 @@ export default class RelatedAgreementField extends React.Component {
   }
 
   componentDidMount() {
-    if (!get(this.props, 'input.value.id')) {
+    if (!get(this.props, 'input.value.id') && this.findAgreementButtonRef.current) {
       this.findAgreementButtonRef.current.focus();
     }
   }

--- a/src/components/RelatedAgreementsFieldArray/RelatedAgreementField.js
+++ b/src/components/RelatedAgreementsFieldArray/RelatedAgreementField.js
@@ -39,6 +39,18 @@ export default class RelatedAgreementField extends React.Component {
     agreement: {},
   }
 
+  constructor(props) {
+    super(props);
+
+    this.findAgreementButtonRef = React.createRef();
+  }
+
+  componentDidMount() {
+    if (!get(this.props, 'input.value.id')) {
+      this.findAgreementButtonRef.current.focus();
+    }
+  }
+
   renderLinkAgreementButton = () => {
     const { id, onAgreementSelected } = this.props;
 
@@ -50,6 +62,7 @@ export default class RelatedAgreementField extends React.Component {
         renderTrigger={(props) => (
           <Button
             buttonStyle="primary"
+            buttonRef={this.findAgreementButtonRef}
             id={`${id}-find-agreement-btn`}
             onClick={props.onClick}
           >


### PR DESCRIPTION
If a repeating field's `Field` component mounts without a value, it means that it was just added via the corresponding `Add new {resource}` button. In that case, we should automatically focus the field's `Add {resource}` button which brings up the `find-{resource}` modal for linking the resource to the agreement being edited.