### PR TITLE
ERM-534: Fixed using stale agreement data on edit route

### DIFF
--- a/src/components/views/AgreementForm.js
+++ b/src/components/views/AgreementForm.js
@@ -43,6 +43,7 @@ class AgreementForm extends React.Component {
       getRegisteredFields: PropTypes.func.isRequired,
     }).isRequired,
     handlers: PropTypes.PropTypes.shape({
+      onBasketLinesAdded: PropTypes.func.isRequired,
       onClose: PropTypes.func.isRequired,
     }),
     initialValues: PropTypes.object,
@@ -72,6 +73,9 @@ class AgreementForm extends React.Component {
     }
   }
 
+  // The `agreementLinesToAdd` must be added here rather than in the parent route
+  // handler because we don't want them to be part of the initialValues.
+  // After all, they're being _added_, so their presence must dirty the form.
   static getDerivedStateFromProps(props, state) {
     if (
       props.data.agreementLinesToAdd.length &&
@@ -82,6 +86,8 @@ class AgreementForm extends React.Component {
         ...(props.initialValues.items || []),
         ...props.data.agreementLinesToAdd,
       ]);
+
+      props.handlers.onBasketLinesAdded();
 
       return { addedLinesToAdd: true };
     }

--- a/src/routes/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute.js
@@ -115,7 +115,7 @@ class AgreementCreateRoute extends React.Component {
     };
   }
 
-  componentWillUnmount() {
+  handleBasketLinesAdded = () => {
     this.props.mutator.query.update({
       addFromBasket: null,
       authority: null,
@@ -194,6 +194,7 @@ class AgreementCreateRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
+          onBasketLinesAdded: this.handleBasketLinesAdded,
           onClose: this.handleClose,
         }}
         initialValues={{

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -156,7 +156,17 @@ class AgreementEditRoute extends React.Component {
     let updated = false;
 
     const agreement = get(props.resources, 'agreement.records[0]', {});
-    const initialValues = state.initialValues.id ? state.initialValues : cloneDeep(agreement);
+
+    // Start with the existing initialValues. However, if we've just fetched a new agreement
+    // then use that as the baseline. This would be the case if we didn't have an agreement in
+    // resources at first, but also if we pulled stale agreement data from `resources` when this
+    // component was inited. Eg, when viewing one agreement and then entering the Edit screen
+    // for another agreement without viewing it first. This would occur when adding to an agreement
+    // via the Basket.
+    let initialValues = state.initialValues;
+    if (initialValues.id !== agreement.id) {
+      initialValues = cloneDeep(agreement);
+    }
 
     const {
       agreementStatus = {},
@@ -169,7 +179,7 @@ class AgreementEditRoute extends React.Component {
       renewalPriority = {},
     } = initialValues;
 
-    if (initialValues.id && !state.initialValues.id) {
+    if (initialValues.id !== state.initialValues.id) {
       updated = true;
 
       // Set the values of dropdown-controlled props as values rather than objects.
@@ -228,7 +238,7 @@ class AgreementEditRoute extends React.Component {
     return null;
   }
 
-  componentWillUnmount() {
+  handleBasketLinesAdded = () => {
     this.props.mutator.query.update({
       addFromBasket: null,
       authority: null,
@@ -316,6 +326,7 @@ class AgreementEditRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
+          onBasketLinesAdded: this.handleBasketLinesAdded,
           onClose: this.handleClose,
         }}
         initialValues={this.state.initialValues}


### PR DESCRIPTION
- The `if` conditions in `gDSFP` were too strict. Relaxed those to also catch scenarios where the agreement fetched has changed (via its id).
- I also fixed a bug where the `addFromBasket` query params weren't being reset properly due to vagaries in the stripes-core reducer. The order of `update()` calls is correct, but at one point `<Root>` takes the location URL as the source of truth rather than the existing state which seems...off...
  - Will debug stripes a bit more but this way of doing things is cleaner and more direct anyway.