### PR TITLE
ERM-564: Support unsetting of optional fields

### DIFF
--- a/src/components/AgreementLinesFieldArray/AgreementLineField.js
+++ b/src/components/AgreementLinesFieldArray/AgreementLineField.js
@@ -160,6 +160,7 @@ export default class AgreementLineField extends React.Component {
               id={`agreement-line-${index}-active-from`}
               label={<FormattedMessage id="ui-agreements.eresources.activeFrom" />}
               name={`${name}.activeFrom`}
+              parse={v => v} // Lets us send an empty string instead of `undefined`
               validate={this.validateDateOrder}
             />
           </Col>
@@ -171,6 +172,7 @@ export default class AgreementLineField extends React.Component {
               id={`agreement-line-${index}-active-to`}
               label={<FormattedMessage id="ui-agreements.eresources.activeTo" />}
               name={`${name}.activeTo`}
+              parse={v => v} // Lets us send an empty string instead of `undefined`
               validate={this.validateDateOrder}
             />
           </Col>

--- a/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
+++ b/src/components/AgreementLinesFieldArray/CustomCoverageFieldArray.js
@@ -66,6 +66,7 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-start-volume-${index}`}
                 label="Start volume"
                 name={`${name}[${index}].startVolume`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
               />
             </Col>
             <Col xs={4}>
@@ -74,6 +75,7 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-start-issue-${index}`}
                 label="Start issue"
                 name={`${name}[${index}].startIssue`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
               />
             </Col>
           </Row>
@@ -86,6 +88,7 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-end-date-${index}`}
                 label="End date"
                 name={`${name}[${index}].endDate`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
                 validate={composeValidators(
                   validators.dateOrder,
                   multipleOpenEndedCoverages,
@@ -99,6 +102,7 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-end-volume-${index}`}
                 label="End volume"
                 name={`${name}[${index}].endVolume`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
               />
             </Col>
             <Col xs={4}>
@@ -107,6 +111,7 @@ class CustomCoverageFieldArray extends React.Component {
                 id={`cc-end-issue-${index}`}
                 label="End issue"
                 name={`${name}[${index}].endIssue`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
               />
             </Col>
           </Row>

--- a/src/components/AgreementPeriodsFieldArray/AgreementPeriodsFieldArray.js
+++ b/src/components/AgreementPeriodsFieldArray/AgreementPeriodsFieldArray.js
@@ -72,6 +72,7 @@ class AgreementPeriodsFieldArray extends React.Component {
                 id={`period-end-date-${index}`}
                 label={<FormattedMessage id="ui-agreements.agreements.endDate" />}
                 name={`${name}[${index}].endDate`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
                 validate={composeValidators(
                   validators.dateOrder,
                   multipleOpenEndedPeriods,
@@ -87,6 +88,7 @@ class AgreementPeriodsFieldArray extends React.Component {
                 id={`period-cancellation-deadline-${index}`}
                 label={<FormattedMessage id="ui-agreements.agreements.cancellationDeadline" />}
                 name={`${name}[${index}].cancellationDeadline`}
+                parse={v => v} // Lets us send an empty string instead of `undefined`
               />
             </Col>
           </Row>
@@ -95,6 +97,7 @@ class AgreementPeriodsFieldArray extends React.Component {
             id={`period-note-${index}`}
             label={<FormattedMessage id="ui-agreements.agreementPeriods.periodNote" />}
             name={`${name}[${index}].note`}
+            parse={v => v} // Lets us send an empty string instead of `undefined`
           />
         </div>
       </EditCard>

--- a/src/components/AgreementSections/FormInfo.js
+++ b/src/components/AgreementSections/FormInfo.js
@@ -92,6 +92,7 @@ export default class FormInfo extends React.Component {
               id="edit-agreement-description"
               label={<FormattedMessage id="ui-agreements.agreements.agreementDescription" />}
               name="description"
+              parse={v => v} // Lets us send an empty string instead of `undefined`
             />
           </Col>
         </Row>
@@ -127,35 +128,35 @@ export default class FormInfo extends React.Component {
           </Col>
           <Col xs={12} md={6}>
             <Field
-              parse={v => v} // Lets us send an empty string instead of `undefined`
               component={Select}
               dataOptions={reasonForClosureValues}
               disabled={values.agreementStatus !== statuses.CLOSED}
               id="edit-agreement-reason-for-closure"
               label={<FormattedMessage id="ui-agreements.agreements.reasonForClosure" />}
               name="reasonForClosure"
+              parse={v => v} // Lets us send an empty string instead of `undefined`
             />
           </Col>
         </Row>
         <Row>
           <Col xs={12} md={6}>
             <Field
-              parse={v => v} // Lets us pass an empty string instead of `undefined`
               component={Select}
               dataOptions={renewalPriorityValues}
               id="edit-agreement-renewal-priority"
               label={<FormattedMessage id="ui-agreements.agreements.renewalPriority" />}
               name="renewalPriority"
+              parse={v => v} // Lets us pass an empty string instead of `undefined`
             />
           </Col>
           <Col xs={12} md={6}>
             <Field
-              parse={v => v} // Lets us pass an empty string instead of `undefined`
               component={Select}
               dataOptions={isPerpetualValues}
               id="edit-agreement-is-perpetual"
               label={<FormattedMessage id="ui-agreements.agreements.isPerpetual" />}
               name="isPerpetual"
+              parse={v => v} // Lets us pass an empty string instead of `undefined`
             />
           </Col>
         </Row>

--- a/src/components/AgreementSections/FormLicenses.js
+++ b/src/components/AgreementSections/FormLicenses.js
@@ -25,11 +25,12 @@ export default class FormLicenses extends React.Component {
 
   renderNote = () => (
     <Field
-      maxLength={255}
-      id="edit-agreement-licenseNote"
-      name="licenseNote"
-      label={<FormattedMessage id="ui-agreements.license.generalNotes" />}
       component={TextArea}
+      id="edit-agreement-licenseNote"
+      label={<FormattedMessage id="ui-agreements.license.generalNotes" />}
+      maxLength={255}
+      name="licenseNote"
+      parse={v => v} // Lets us send an empty string instead of `undefined`
     />
   )
 

--- a/src/components/LicensesFieldArray/AmendmentsFieldArray.js
+++ b/src/components/LicensesFieldArray/AmendmentsFieldArray.js
@@ -147,6 +147,7 @@ class AmendmentsFieldArray extends React.Component {
                     component={TextArea}
                     label={<FormattedMessage id="ui-agreements.license.amendmentNote" />}
                     name={`${name}[${i}].note`}
+                    parse={v => v} // Lets us send an empty string instead of `undefined`
                   />
                 </Col>
               </Row>

--- a/src/components/LicensesFieldArray/LicensesFieldArray.js
+++ b/src/components/LicensesFieldArray/LicensesFieldArray.js
@@ -108,6 +108,7 @@ class LicensesFieldArray extends React.Component {
               id={`${name}-note-${index}`}
               label={<FormattedMessage id="ui-agreements.license.prop.note" />}
               name={`${name}[${index}].note`}
+              parse={v => v} // Lets us send an empty string instead of `undefined`
             />
           </Col>
         </Row>

--- a/src/components/RelatedAgreementsFieldArray/RelatedAgreementsFieldArray.js
+++ b/src/components/RelatedAgreementsFieldArray/RelatedAgreementsFieldArray.js
@@ -112,6 +112,7 @@ class RelatedAgreementsFieldArray extends React.Component {
           id={`ra-note-${index}`}
           label={<FormattedMessage id="ui-agreements.note" />}
           name={`${this.props.name}[${index}].note`}
+          parse={v => v} // Lets us send an empty string instead of `undefined`
         />
       </EditCard>
     ));

--- a/src/components/UsageDataProvidersFieldArray/UsageDataProvidersFieldArray.js
+++ b/src/components/UsageDataProvidersFieldArray/UsageDataProvidersFieldArray.js
@@ -66,6 +66,7 @@ class UsageDataProvidersFieldArray extends React.Component {
           id={`udp-note-${index}`}
           label={<FormattedMessage id="ui-agreements.usageData.note" />}
           name={`${this.props.name}[${index}].usageDataProviderNote`}
+          parse={v => v} // Lets us send an empty string instead of `undefined`
         />
       </EditCard>
     ));

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -76,7 +76,7 @@ class AgreementEditRoute extends React.Component {
 
         return query ? { query } : {};
       },
-      fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0'),
+      fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0 8.0'),
       records: 'poLines',
     },
     orgRoleValues: {


### PR DESCRIPTION
[ERM-564](https://issues.folio.org/browse/ERM-564)

Backends written in Groovy do not interpret an undefined value as being an "unsetting" of a field. Eg, if a given record has `{ id: 1, foo: "bar", bar: "baz" }` and I PUT `{ id: 1, foo: "aubergine" }`, then the record will now have `{ id: 1, foo: "aubergine", bar: "baz" }`.

This is a problem for us because [React Final Form coalesces empty strings into undefineds](https://final-form.org/docs/final-form/faq#why-does-final-form-set-my--field-value-to-undefined). To work around this, we use [the docs' suggested `parse` hack](https://final-form.org/docs/react-final-form/types/FieldProps#parse).