### PR TITLE
Lines: Use start/endDate instead of activeFrom/To

### DIFF
--- a/src/components/AgreementSections/LinesList.js
+++ b/src/components/AgreementSections/LinesList.js
@@ -58,8 +58,8 @@ export default class LinesList extends React.Component {
     },
     provider: line => <EResourceProvider resource={line.resource || line} />,
     type: line => <EResourceType resource={getResourceFromEntitlement(line)} />,
-    activeFrom: line => <div data-test-active-from>{this.renderDate(line.activeFrom)}</div>,
-    activeTo: line => <div data-test-active-to>{this.renderDate(line.activeTo)}</div>,
+    activeFrom: line => <div data-test-active-from>{this.renderDate(line.startDate)}</div>,
+    activeTo: line => <div data-test-active-to>{this.renderDate(line.endDate)}</div>,
     count: line => <EResourceCount resource={getResourceFromEntitlement(line)} />,
     coverage: line => <CoverageStatements statements={line.coverage} />,
     isCustomCoverage: line => {

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -228,8 +228,8 @@ class AgreementEditRoute extends React.Component {
           id: line.id,
           coverage: line.customCoverage ? line.coverage : undefined,
           poLines: line.poLines,
-          activeFrom: line.activeFrom,
-          activeTo: line.activeTo
+          activeFrom: line.startDate,
+          activeTo: line.endDate
         };
       });
     }


### PR DESCRIPTION
External Entitlements don't render the activeTo/From fields so use the more generic start/endDate fields which pull from the same datasource.