### PR TITLE
Fixed agreement line activeTo/From validation

### DIFF
--- a/src/components/AgreementLinesFieldArray/AgreementLineField.js
+++ b/src/components/AgreementLinesFieldArray/AgreementLineField.js
@@ -27,7 +27,7 @@ export default class AgreementLineField extends React.Component {
       name: PropTypes.string.isRequired,
     }).isRequired,
     meta: PropTypes.shape({
-      error: PropTypes.node,
+      error: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
     }).isRequired,
     onDelete: PropTypes.func,
     onResourceSelected: PropTypes.func,
@@ -45,16 +45,16 @@ export default class AgreementLineField extends React.Component {
       let activeTo;
 
       if (meta.name.indexOf('activeFrom') >= 0) {
-        activeFrom = new Date(value);
-        activeTo = new Date(get(allValues, meta.name.replace('activeFrom', 'activeTo')));
+        activeFrom = value;
+        activeTo = get(allValues, meta.name.replace('activeFrom', 'activeTo'));
       } else if (meta.name.indexOf('endDate') >= 0) {
-        activeFrom = new Date(get(allValues, meta.name.replace('activeTo', 'activeFrom')));
-        activeTo = new Date(value);
+        activeFrom = get(allValues, meta.name.replace('activeTo', 'activeFrom'));
+        activeTo = value;
       } else {
         return undefined;
       }
 
-      if (activeFrom >= activeTo) {
+      if (activeFrom && activeTo && new Date(activeFrom) >= new Date(activeTo)) {
         return (
           <div data-test-error-end-date-too-early>
             <FormattedMessage id="ui-agreements.errors.endDateGreaterThanStartDate" />

--- a/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.js
+++ b/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.js
@@ -19,9 +19,6 @@ class AgreementLinesFieldArray extends React.Component {
       orderLines: PropTypes.array,
     }),
     items: PropTypes.arrayOf(PropTypes.object),
-    meta: PropTypes.shape({
-      error: PropTypes.object,
-    }),
     name: PropTypes.string.isRequired,
     onAddField: PropTypes.func.isRequired,
     onDeleteField: PropTypes.func.isRequired,


### PR DESCRIPTION
The current code always pulled the activeTo/From values and assumed they were valid, which is incorrect. 

For example, if `activeTo` wasn't set in the form, then `activeTo = new Date(get(allValues, meta.name.replace('activeFrom', 'activeTo')));` results in setting the `activeTo` variable to the start of the UNIX epoch, Dec 31 1969. 

This then results in any `activeFrom` value greater than 1970 failing validation.