### PR TITLE
ERM-636: Use Spinner and FormattedUTCDate from Stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-agreements
 
+##  3.4.0 IN PROGRESS
+* Switched to using `<FormattedUTCDate>` from Stripes. ERM-635
+* Switched to using `<Spinner>` from Stripes. ERM-635
+
 ## 3.3.0 2019-12-04
 * Update stripes to v2.10.1 to support PaneFooter.
 * Move the Save & close button and add a Cancel button to Pane Footer. ERM-411.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^4.2.0",
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "@folio/stripes-cli": "^1.8.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
@@ -82,7 +82,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "react": "*",
     "react-dom": "*",
     "react-redux": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/agreements",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "ERM agreement functionality for Stripes",
   "main": "src/index.js",
   "publishConfig": {

--- a/src/components/AgreementSections/CoveredEResourcesList.js
+++ b/src/components/AgreementSections/CoveredEResourcesList.js
@@ -9,6 +9,7 @@ import {
   Dropdown,
   DropdownButton,
   DropdownMenu,
+  FormattedUTCDate,
   Headline,
   Icon,
   Layout,
@@ -22,7 +23,6 @@ import { getResourceIdentifier } from '../utilities';
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';
 import EResourceLink from '../EResourceLink';
-import FormattedUTCDate from '../FormattedUTCDate';
 import IfEResourcesEnabled from '../IfEResourcesEnabled';
 
 export default class CoveredEResourcesList extends React.Component {

--- a/src/components/AgreementSections/CoveredEResourcesList.js
+++ b/src/components/AgreementSections/CoveredEResourcesList.js
@@ -14,10 +14,10 @@ import {
   Layout,
   MultiColumnList,
   Row,
+  Spinner,
   Tooltip,
 } from '@folio/stripes/components';
 
-import { Spinner } from '@folio/stripes-erm-components';
 import { getResourceIdentifier } from '../utilities';
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';

--- a/src/components/AgreementSections/Header.js
+++ b/src/components/AgreementSections/Header.js
@@ -5,11 +5,11 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
+  FormattedUTCDate,
   KeyValue,
   Row,
 } from '@folio/stripes/components';
 
-import FormattedUTCDate from '../FormattedUTCDate';
 import css from './Header.css';
 
 export default class Header extends React.Component {

--- a/src/components/AgreementSections/Info.js
+++ b/src/components/AgreementSections/Info.js
@@ -4,12 +4,12 @@ import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 import {
   Col,
+  FormattedUTCDate,
   Headline,
   KeyValue,
   Row,
 } from '@folio/stripes/components';
 
-import FormattedUTCDate from '../FormattedUTCDate';
 import { statuses } from '../../constants';
 
 export default class Info extends React.Component {

--- a/src/components/AgreementSections/Lines.js
+++ b/src/components/AgreementSections/Lines.js
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
-import { Badge, Accordion } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import { Accordion, Badge, Spinner } from '@folio/stripes/components';
 
 import CoveredEResourcesList from './CoveredEResourcesList';
 import LinesList from './LinesList';
-
 
 export default class Lines extends React.Component {
   static propTypes = {

--- a/src/components/AgreementSections/LinesList.js
+++ b/src/components/AgreementSections/LinesList.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
-import { MultiColumnList, Tooltip } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import { MultiColumnList, Spinner, Tooltip } from '@folio/stripes/components';
 
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';

--- a/src/components/AgreementSections/LinesList.js
+++ b/src/components/AgreementSections/LinesList.js
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types';
 import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
-import { MultiColumnList, Spinner, Tooltip } from '@folio/stripes/components';
+import {
+  FormattedUTCDate,
+  MultiColumnList,
+  Spinner,
+  Tooltip
+} from '@folio/stripes/components';
 
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';
@@ -11,7 +16,6 @@ import EResourceLink from '../EResourceLink';
 import EResourceCount from '../EResourceCount';
 import EResourceProvider from '../EResourceProvider';
 import EResourceType from '../EResourceType';
-import FormattedUTCDate from '../FormattedUTCDate';
 import { getResourceFromEntitlement, urls } from '../utilities';
 
 export default class LinesList extends React.Component {

--- a/src/components/AgreementSections/OtherPeriods.js
+++ b/src/components/AgreementSections/OtherPeriods.js
@@ -2,9 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { Badge, Accordion, MultiColumnList } from '@folio/stripes/components';
-
-import FormattedUTCDate from '../FormattedUTCDate';
+import {
+  Accordion,
+  Badge,
+  FormattedUTCDate,
+  MultiColumnList,
+} from '@folio/stripes/components';
 
 export default class OtherPeriods extends React.Component {
   static propTypes = {

--- a/src/components/CoverageStatements/CoverageStatements.js
+++ b/src/components/CoverageStatements/CoverageStatements.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { Icon, Layout } from '@folio/stripes/components';
-
-import FormattedUTCDate from '../FormattedUTCDate';
+import { FormattedUTCDate, Icon, Layout } from '@folio/stripes/components';
 
 export default class CoverageStatements extends React.Component {
   static propTypes = {

--- a/src/components/EResourceSections/AcquisitionOptions.js
+++ b/src/components/EResourceSections/AcquisitionOptions.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge, MultiColumnList } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import { Accordion, Badge, MultiColumnList, Spinner } from '@folio/stripes/components';
 
 import AddToBasketButton from '../AddToBasketButton';
 import EResourceLink from '../EResourceLink';

--- a/src/components/EResourceSections/Agreements.js
+++ b/src/components/EResourceSections/Agreements.js
@@ -4,13 +4,18 @@ import { get } from 'lodash';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge, MultiColumnList, Spinner } from '@folio/stripes/components';
+import {
+  Accordion,
+  Badge,
+  FormattedUTCDate,
+  MultiColumnList,
+  Spinner
+} from '@folio/stripes/components';
 
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';
 import EResourceLink from '../EResourceLink';
 import EResourceType from '../EResourceType';
-import FormattedUTCDate from '../FormattedUTCDate';
 import { getResourceFromEntitlement, urls } from '../utilities';
 
 export default class Agreements extends React.Component {

--- a/src/components/EResourceSections/Agreements.js
+++ b/src/components/EResourceSections/Agreements.js
@@ -4,8 +4,7 @@ import { get } from 'lodash';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge, MultiColumnList } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import { Accordion, Badge, MultiColumnList, Spinner } from '@folio/stripes/components';
 
 import CoverageStatements from '../CoverageStatements';
 import CustomCoverageIcon from '../CustomCoverageIcon';

--- a/src/components/EResourceSections/PackageContents.js
+++ b/src/components/EResourceSections/PackageContents.js
@@ -3,8 +3,15 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge, Button, ButtonGroup, Layout, MultiColumnList } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import {
+  Accordion,
+  Badge,
+  Button,
+  ButtonGroup,
+  Layout,
+  MultiColumnList,
+  Spinner,
+} from '@folio/stripes/components';
 
 import CoverageStatements from '../CoverageStatements';
 import EResourceLink from '../EResourceLink';

--- a/src/components/EResourceSections/PackageContents.js
+++ b/src/components/EResourceSections/PackageContents.js
@@ -8,6 +8,7 @@ import {
   Badge,
   Button,
   ButtonGroup,
+  FormattedUTCDate,
   Layout,
   MultiColumnList,
   Spinner,
@@ -15,7 +16,6 @@ import {
 
 import CoverageStatements from '../CoverageStatements';
 import EResourceLink from '../EResourceLink';
-import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class PackageContents extends React.Component {
   static propTypes = {

--- a/src/components/FormattedUTCDate/FormattedUTCDate.js
+++ b/src/components/FormattedUTCDate/FormattedUTCDate.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import { FormattedDate } from 'react-intl';
-
-export default function FormattedUTCDate(props) {
-  return <FormattedDate timeZone="UTC" {...props} />;
-}

--- a/src/components/FormattedUTCDate/index.js
+++ b/src/components/FormattedUTCDate/index.js
@@ -1,1 +1,0 @@
-export { default } from './FormattedUTCDate';

--- a/src/components/LicenseAmendmentList/LicenseAmendmentList.js
+++ b/src/components/LicenseAmendmentList/LicenseAmendmentList.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import Link from 'react-router-dom/Link';
 
-import { Icon, MultiColumnList, Tooltip } from '@folio/stripes/components';
+import {
+  Icon,
+  FormattedUTCDate,
+  MultiColumnList,
+  Tooltip
+} from '@folio/stripes/components';
 import { LicenseEndDate } from '@folio/stripes-erm-components';
 
-import FormattedUTCDate from '../FormattedUTCDate';
 import { urls, getConflictWarnings } from '../utilities';
 import css from './LicenseAmendmentList.css';
 

--- a/src/components/LicensesFieldArray/AmendmentsFieldArray.js
+++ b/src/components/LicensesFieldArray/AmendmentsFieldArray.js
@@ -4,11 +4,20 @@ import { get } from 'lodash';
 import Link from 'react-router-dom/Link';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
-import { Card, Col, Headline, MessageBanner, KeyValue, Row, Select, TextArea } from '@folio/stripes/components';
+import {
+  Card,
+  Col,
+  FormattedUTCDate,
+  Headline,
+  MessageBanner,
+  KeyValue,
+  Row,
+  Select,
+  TextArea
+} from '@folio/stripes/components';
 import { LicenseEndDate, withKiwtFieldArray } from '@folio/stripes-erm-components';
 
 import { urls, getConflictWarnings, validators } from '../utilities';
-import FormattedUTCDate from '../FormattedUTCDate';
 
 class AmendmentsFieldArray extends React.Component {
   static propTypes = {

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -5,14 +5,15 @@ import { get, noop } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import {
-  MultiColumnList,
-  SearchField,
-  Pane,
-  Icon,
   Button,
   ButtonGroup,
+  FormattedUTCDate,
+  Icon,
+  MultiColumnList,
+  Pane,
   PaneMenu,
   Paneset,
+  SearchField,
 } from '@folio/stripes/components';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
@@ -25,7 +26,6 @@ import {
 
 import { statuses } from '../../constants';
 import AgreementFilters from '../AgreementFilters';
-import FormattedUTCDate from '../FormattedUTCDate';
 import IfEResourcesEnabled from '../IfEResourcesEnabled';
 import { urls } from '../utilities';
 import css from './Agreements.css';

--- a/src/components/views/Basket.js
+++ b/src/components/views/Basket.js
@@ -5,17 +5,17 @@ import { FormattedMessage } from 'react-intl';
 import {
   Button,
   Col,
+  FormattedUTCDate,
   Headline,
   IconButton,
   Pane,
   PaneMenu,
+  Paneset,
   Row,
   Selection,
-  Paneset,
 } from '@folio/stripes/components';
 
 import BasketList from '../BasketList';
-import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class Basket extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Spinner and FormattedUTCDate were promoted to Stripes as of version 2.12.0 so we should switch to pulling them from there from now on.