### PR TITLE
Support updated Dropdown API

### DIFF
--- a/src/components/AgreementSections/CoveredEResourcesList.js
+++ b/src/components/AgreementSections/CoveredEResourcesList.js
@@ -5,9 +5,9 @@ import { FormattedMessage } from 'react-intl';
 import {
   Button,
   ButtonGroup,
+  Callout,
   Col,
   Dropdown,
-  DropdownButton,
   DropdownMenu,
   FormattedUTCDate,
   Headline,
@@ -39,8 +39,10 @@ export default class CoveredEResourcesList extends React.Component {
     visible: PropTypes.bool,
   };
 
-  state = {
-    exportDropdownOpen: false,
+  constructor(props) {
+    super(props);
+
+    this.callout = React.createRef();
   }
 
   columnMapping = {
@@ -99,8 +101,13 @@ export default class CoveredEResourcesList extends React.Component {
     'accessEnd',
   ]
 
-  handleToggleExportDropdown = () => {
-    this.setState(prevState => ({ exportDropdownOpen: prevState.exportDropdownOpen }));
+  export = (exportCallback) => {
+    const calloutId = this.callout.current.sendCallout({
+      message: <FormattedMessage id="ui-agreements.eresourcesCovered.preparingExport" />,
+      timeout: 0,
+    });
+
+    exportCallback().then(() => this.callout.current.removeCallout(calloutId));
   }
 
   renderDate = date => (
@@ -109,29 +116,22 @@ export default class CoveredEResourcesList extends React.Component {
 
   renderExportDropdown = (disabled) => (
     <Dropdown
-      onToggle={() => this.setState(prevState => ({ exportDropdownOpen: !prevState.exportDropdownOpen }))}
-      open={this.state.exportDropdownOpen}
-      disabled={disabled}
+      buttonProps={{
+        'data-test-export-button': true,
+        'disabled': disabled,
+        'marginBottom0': true,
+      }}
+      label={<FormattedMessage id="ui-agreements.eresourcesCovered.exportAs" />}
     >
-      <DropdownButton
-        data-test-export-button
-        data-role="toggle"
-        marginBottom0
-      >
-        <FormattedMessage id="ui-agreements.eresourcesCovered.exportAs" />
-      </DropdownButton>
-      <DropdownMenu data-role="menu">
+      <DropdownMenu role="menu">
         <FormattedMessage id="ui-agreements.eresourcesCovered.exportAsJSON">
           {exportAsJson => (
             <Button
               aria-label={exportAsJson}
               buttonStyle="dropdownItem"
-              disabled={disabled}
               id="clickable-dropdown-export-eresources-json"
-              onClick={() => {
-                this.setState({ exportDropdownOpen: false });
-                this.props.onExportEResourcesAsJSON();
-              }}
+              onClick={() => this.export(this.props.onExportEResourcesAsJSON)}
+              role="menuitem"
             >
               <FormattedMessage id="ui-agreements.eresourcesCovered.json" />
             </Button>
@@ -142,12 +142,9 @@ export default class CoveredEResourcesList extends React.Component {
             <Button
               aria-label={exportAsKbart}
               buttonStyle="dropdownItem"
-              disabled={disabled}
               id="clickable-dropdown-export-eresources-kbart"
-              onClick={() => {
-                this.setState({ exportDropdownOpen: false });
-                this.props.onExportEResourcesAsKBART();
-              }}
+              onClick={() => this.export(this.props.onExportEResourcesAsKBART)}
+              role="menuitem"
             >
               <FormattedMessage id="ui-agreements.eresourcesCovered.kbart" />
             </Button>
@@ -239,6 +236,7 @@ export default class CoveredEResourcesList extends React.Component {
           </Col>
         </Row>
         {eresources ? this.renderList() : <Spinner />}
+        <Callout ref={this.callout} />
       </IfEResourcesEnabled>
     );
   }

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -75,7 +75,7 @@ class AgreementEditRoute extends React.Component {
           ))
           .join(' or ');
 
-        return query ? { query } : {};
+        return query ? { query } : null;
       },
       fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0 8.0'),
       records: 'poLines',
@@ -99,7 +99,7 @@ class AgreementEditRoute extends React.Component {
           .map(contact => `id==${contact.user}`)
           .join(' or ');
 
-        return query ? { query } : {};
+        return query ? { query } : null;
       },
       fetch: props => !!props.stripes.hasInterface('users', '15.0'),
       records: 'users',

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -60,7 +60,7 @@ class AgreementViewRoute extends React.Component {
           ...new Set(interfaces.map(i => `id==${i}`))
         ].join(' or ');
 
-        return query ? { query } : {};
+        return query ? { query } : null;
       },
       fetch: props => !!props.stripes.hasInterface('organizations-storage.interfaces', '2.0'),
       records: 'interfaces',
@@ -77,7 +77,7 @@ class AgreementViewRoute extends React.Component {
           ))
           .join(' or ');
 
-        return query ? { query } : {};
+        return query ? { query } : null;
       },
       fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0 8.0'),
       records: 'poLines',
@@ -96,7 +96,7 @@ class AgreementViewRoute extends React.Component {
           .map(contact => `id==${contact.user}`)
           .join(' or ');
 
-        return query ? { query } : {};
+        return query ? { query } : null;
       },
       fetch: props => !!props.stripes.hasInterface('users', '15.0'),
       records: 'users',

--- a/test/ui-testing/agreement-crud.js
+++ b/test/ui-testing/agreement-crud.js
@@ -16,7 +16,7 @@ const generateAgreementValues = () => {
 
 const agreementLines = () => {
   const activeFrom = '2019-10-13';
-  const activeTo = '2019-10-31';
+  const activeTo = '2030-10-31';
   return {
     activeFrom,
     activeTo,

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -202,6 +202,7 @@
   "eresourcesCovered.json": "JSON",
   "eresourcesCovered.kbart": "KBART",
   "eresourcesCovered.exportButton.tooltip": "Exports only supported for current or all resources",
+  "eresourcesCovered.preparingExport": "Creating export file...this may take a few minutes for large agreements",
 
   "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
   "errors.multipleOpenEndedCoverages": "Cannot have multiple open-ended coverage statements.",


### PR DESCRIPTION
- Added Callout for when exporting resources. 
  - While testing the Dropdown changes, I realised that exporting a resources list that's really long is super confusing because you get no notification. So I added a Callout.
  - Additionally, this Callout uses the functionality I added in https://github.com/folio-org/stripes-components/pull/1130 to autohide when the download is done.
- Fixed Custom Coverage test by having the agreement creation helper not add expired agreement lines
  - The custom coverage test was looking for an entry in the eresources covered list, but the eresources wasn't there because the default filter is 'Current', and the line was added with an expired access date.