### PR TITLE
ERM-654: Disable ag line sort

### DIFF
--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -24,7 +24,8 @@ class AgreementEditRoute extends React.Component {
       path: 'erm/entitlements',
       params: {
         match: 'owner.id',
-        sort: 'resource.name',
+        // Sort is disabled until ERM-655 is fixed
+        // sort: 'resource.name',
         stats: 'true',
         term: ':{id}',
       },

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -28,7 +28,8 @@ class AgreementViewRoute extends React.Component {
       path: 'erm/entitlements',
       params: {
         match: 'owner.id',
-        sort: 'resource.name',
+        // Sort is disabled until ERM-655 is fixed
+        // sort: 'resource.name',
         stats: 'true',
         term: ':{id}',
       },


### PR DESCRIPTION
The last PR handled _viewing_ the agreement lines, but it missed loading them up when editing the agreement.