### PR TITLE
Display spinner in E-resource in package accordion when selecting a n…

### DIFF
--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -170,10 +170,11 @@ class EResourceViewRoute extends React.Component {
 
   getPackageContentsRecords = () => {
     const { resources, match } = this.props;
+    const packageContentsUrl = get(resources, 'packageContents.url', '');
 
-    if (get(resources, 'packageContents.url', '').indexOf(`${match.params.id}`) === -1) {
+    if (packageContentsUrl.indexOf(`${match.params.id}`) === -1) {
       return undefined;
-    } else if (get(resources, 'packageContents.url', '').indexOf(`content/${resources.packageContentsFilter}`) === -1) {
+    } else if (packageContentsUrl.indexOf(`content/${resources.packageContentsFilter}`) === -1) {
       return undefined;
     }
 

--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -160,13 +160,24 @@ class EResourceViewRoute extends React.Component {
     );
   }
 
-  getPackageContentsRecords = () => {
-    const { resources } = this.props;
-    return get(resources, 'packageContents.url', '').indexOf(`content/${resources.packageContentsFilter}`) > -1
+  getPackageContentsRecordsCount() {
+    return this.getPackageContentsRecords()
       ?
-      get(resources, 'packageContents.records')
+      get(this.props.resources, 'packageContents.other.totalRecords', 0)
       :
-      undefined;
+      0;
+  }
+
+  getPackageContentsRecords = () => {
+    const { resources, match } = this.props;
+
+    if (get(resources, 'packageContents.url', '').indexOf(`${match.params.id}`) === -1) {
+      return undefined;
+    } else if (get(resources, 'packageContents.url', '').indexOf(`content/${resources.packageContentsFilter}`) === -1) {
+      return undefined;
+    }
+
+    return get(resources, 'packageContents.records');
   }
 
   getRecords = (resource) => {
@@ -192,7 +203,7 @@ class EResourceViewRoute extends React.Component {
           entitlements: this.getRecords('entitlements'),
           packageContentsFilter: this.props.resources.packageContentsFilter,
           packageContents: this.getPackageContentsRecords(),
-          packageContentsCount: get(this.props.resources, 'packageContents.other.totalRecords', 0),
+          packageContentsCount: this.getPackageContentsRecordsCount(),
         }}
         handlers={{
           ...handlers,

--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -172,13 +172,13 @@ class EResourceViewRoute extends React.Component {
     const { resources, match } = this.props;
     const packageContentsUrl = get(resources, 'packageContents.url', '');
 
-    if (packageContentsUrl.indexOf(`${match.params.id}`) === -1) {
-      return undefined;
-    } else if (packageContentsUrl.indexOf(`content/${resources.packageContentsFilter}`) === -1) {
-      return undefined;
-    }
-
-    return get(resources, 'packageContents.records');
+    // If a new eresource is selected or if the filter has changed return undefined
+    return (packageContentsUrl.indexOf(`${match.params.id}`) === -1 ||
+      packageContentsUrl.indexOf(`content/${resources.packageContentsFilter}`) === -1)
+      ?
+      undefined
+      :
+      get(resources, 'packageContents.records');
   }
 
   getRecords = (resource) => {


### PR DESCRIPTION
…ew Eresource, refs ERM-642

Check if the `id` in the URL is present in the `packageContents` resource URL and if not, show a spinner