### PR TITLE
ERM-652: Support orders 9.0 interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
       "configuration": "2.0 3.0 4.0 5.0",
       "erm": "2.0",
       "licenses": "1.0 2.0",
-      "orders": "6.0 7.0 8.0",
+      "orders": "9.0",
+      "order-lines": "1.0",
       "organizations-storage.interfaces": "2.0",
       "users": "13.0 14.0 15.0"
     },

--- a/src/components/AgreementLinesFieldArray/POLineField.js
+++ b/src/components/AgreementLinesFieldArray/POLineField.js
@@ -28,7 +28,7 @@ export default class POLineField extends React.Component {
     poLine: PropTypes.shape({
       acquisitionMethod: PropTypes.string,
       poLineNumber: PropTypes.string,
-      title: PropTypes.string,
+      titleOrPackage: PropTypes.string,
     }),
   }
 
@@ -107,7 +107,7 @@ export default class POLineField extends React.Component {
           <Col xs={12}>
             <KeyValue label={<FormattedMessage id="ui-agreements.poLines.title" />}>
               <div data-test-poline-title>
-                {poLine.title || '-'}
+                {poLine.titleOrPackage || '-'}
               </div>
             </KeyValue>
           </Col>

--- a/src/components/AgreementSections/LinesList.js
+++ b/src/components/AgreementSections/LinesList.js
@@ -112,7 +112,7 @@ export default class LinesList extends React.Component {
               id={`tooltip-${line.id}-${poLine.id}`}
               key={poLine.id}
               placement="left"
-              text={poLine.title}
+              text={poLine.titleOrPackage}
             >
               {({ ref, ariaIds }) => (
                 <div

--- a/test/bigtest/helpers/findPOLineModule.js
+++ b/test/bigtest/helpers/findPOLineModule.js
@@ -12,7 +12,7 @@ for (let i = 0; i < 100; i++) {
     acquisitionMethod: faker.finance.transactionType(),
     id: uuid(),
     poLineNumber: `${number()}-${number()}`,
-    title: words(),
+    titleOrPackage: words(),
   };
 }
 

--- a/test/bigtest/tests/po-lines-test.js
+++ b/test/bigtest/tests/po-lines-test.js
@@ -35,7 +35,7 @@ describe('PO Lines', () => {
 
     expect(agreementForm.linesSection.lines(agreementLineIndex).poLines(poLineIndex).acquisitionMethod).to.equal(poLine.acquisitionMethod);
     expect(agreementForm.linesSection.lines(agreementLineIndex).poLines(poLineIndex).poLineNumber).to.include(poLine.poLineNumber);
-    expect(agreementForm.linesSection.lines(agreementLineIndex).poLines(poLineIndex).title).to.equal(poLine.title);
+    expect(agreementForm.linesSection.lines(agreementLineIndex).poLines(poLineIndex).titleOrPackage).to.equal(poLine.titleOrPackage);
   };
 
   beforeEach(async function () {


### PR DESCRIPTION
- Depend on new `order-lines` `1.0` interface
- Use `poLine.titleOrPackage` instead of `title`