### PR TITLE
Use resultOffset as a function to return the correct offset, refs ERM…

### DIFF
--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -174,7 +174,7 @@ class EResourceViewRoute extends React.Component {
   }
 
   getPackageContentsRecords = () => {
-    const { resources, match, mutator } = this.props;
+    const { resources, match } = this.props;
     const packageContentsUrl = get(resources, 'packageContents.url', '');
 
     // If a new eresource is selected or if the filter has changed return undefined

--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -41,7 +41,12 @@ class EResourceViewRoute extends React.Component {
       records: 'results',
       limitParam: 'perPage',
       perRequest: resultCount.RESULT_COUNT_INCREMENT,
-      resultOffset: '%{packageContentsOffset}',
+      resultOffset: (_q, _p, _r, _l, props) => {
+        const { match, resources } = props;
+        const resultOffset = get(resources, 'packageContentsOffset');
+        const eresourceId = get(resources, 'eresource.records[0].id');
+        return eresourceId !== match.params.id ? 0 : resultOffset;
+      },
       params: {
         filters: 'pkg.id==:{id}',
         sort: 'pti.titleInstance.name;asc',
@@ -169,7 +174,7 @@ class EResourceViewRoute extends React.Component {
   }
 
   getPackageContentsRecords = () => {
-    const { resources, match } = this.props;
+    const { resources, match, mutator } = this.props;
     const packageContentsUrl = get(resources, 'packageContents.url', '');
 
     // If a new eresource is selected or if the filter has changed return undefined


### PR DESCRIPTION
…-642

The resultOffset option passed to stripes-connect can be passed in as a function and the props passed back as a part of the callback can be used to check if the id from the URL `match.params.id` matches the id of the `eresource` loaded. If they don't match, it means we either have selected a different eresource or the eresource view pane is being loaded for the first time. In that case return 0 as the resultOffset. If not, just return the local resource `packageContentsOffset`