### PR TITLE
AgViewRoute: Update hasInterface check

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
       "configuration": "2.0 3.0 4.0 5.0",
       "erm": "2.0",
       "licenses": "1.0 2.0",
-      "orders": "9.0",
       "order-lines": "1.0",
       "organizations-storage.interfaces": "2.0",
       "users": "13.0 14.0 15.0"

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -80,7 +80,7 @@ class AgreementViewRoute extends React.Component {
 
         return query ? { query } : null;
       },
-      fetch: props => !!props.stripes.hasInterface('orders', '6.0 7.0 8.0'),
+      fetch: props => !!props.stripes.hasInterface('order-lines', '1.0'),
       records: 'poLines',
     },
     terms: {


### PR DESCRIPTION
The `okapiInterfaces` was updated previously but not the `hasInterface` check so the order-lines fetches were never happening.