### PR TITLE
Use pagingType click, refs ERM-642

### DIFF
--- a/src/components/EResourceSections/PackageContents.js
+++ b/src/components/EResourceSections/PackageContents.js
@@ -65,7 +65,7 @@ export default class PackageContents extends React.Component {
         maxHeight={800}
         onNeedMoreData={this.props.onNeedMorePackageContents}
         pageAmount={resultCount.RESULT_COUNT_INCREMENT}
-        pagingType="scroll"
+        pagingType="click"
         totalCount={packageContentsCount}
         virtualize
         visibleColumns={this.visibleColumns}

--- a/src/components/views/EResources.js
+++ b/src/components/views/EResources.js
@@ -316,7 +316,7 @@ export default class EResources extends React.Component {
                       isSelected={({ item }) => item.id === selectedRecordId}
                       onRowClick={onSelectRow}
                       pageAmount={resultCount.RESULT_COUNT_INCREMENT}
-                      pagingType="scroll"
+                      pagingType="click"
                       rowFormatter={this.rowFormatter}
                       sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
                       sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}


### PR DESCRIPTION
Renders a load more button which on click will render the next N results (currently 100). Opting in for this behavior until the scroll functionality is well supported. Opting in to scroll should be as easy as changing the `pagingType` prop to `scroll`