### PR TITLE
Render null coverage as null instead of hyphen

### DIFF
--- a/src/components/AgreementSections/FormInternalContacts.js
+++ b/src/components/AgreementSections/FormInternalContacts.js
@@ -30,7 +30,7 @@ export default class FormInternalContacts extends React.Component {
         <FieldArray
           component={InternalContactsFieldArray}
           contactRoles={this.props.data.contactRoleValues}
-          isEmptyMessage={<FormattedMessage id="ui-agreements.contacts.noContacts" />}
+          isEmptyMessage={<FormattedMessage id="ui-agreements.emptyAccordion.internalContacts" />}
           name="contacts"
           users={this.props.data.users}
         />

--- a/src/components/Coverage/MonographCoverage.js
+++ b/src/components/Coverage/MonographCoverage.js
@@ -42,13 +42,14 @@ export default class MonographCoverage extends React.Component {
 
   renderCoverage(pci) {
     // Date can take the forms yyyy, yyyy-mm or yyyy-mm-dd, and is stored as a string.
-    const date = get(pci, 'pti.titleInstance.dateMonographPublished');
-    const volume = get(pci, 'pti.titleInstance.monographVolume');
-    const edition = get(pci, 'pti.titleInstance.monographEdition');
+    const date = pci?.pti?.titleInstance?.dateMonographPublished;
+    const volume = pci?.pti?.titleInstance?.monographVolume;
+    const edition = pci?.pti?.titleInstance?.monographEdition;
 
     if (!date && !volume && !edition) {
       return '*';
     }
+
     return (
       <Layout
         className="full indent"
@@ -71,9 +72,14 @@ export default class MonographCoverage extends React.Component {
 
   render() {
     const { pci } = this.props;
-    const titleName = get(pci, 'pti.titleInstance.name');
+    const titleName = pci?.pti?.titleInstance?.name;
 
-    if (!pci) return '-';
-    return <Layout className="full" data-test-monograph-coverage={titleName}>{this.renderCoverage(pci)}</Layout>;
+    if (!pci) return null;
+
+    return (
+      <Layout className="full" data-test-monograph-coverage={titleName}>
+        {this.renderCoverage(pci)}
+      </Layout>
+    );
   }
 }

--- a/src/components/Coverage/SerialCoverage.js
+++ b/src/components/Coverage/SerialCoverage.js
@@ -68,7 +68,7 @@ export default class SerialCoverage extends React.Component {
     } = statement;
 
     if (!startDate && !startVolume && !startIssue && !endDate && !endVolume && !endIssue) {
-      return '';
+      return null;
     }
 
     return (
@@ -98,8 +98,12 @@ export default class SerialCoverage extends React.Component {
 
   render() {
     const { statements } = this.props;
-    if (!statements || !statements.length) return '-';
+    if (!statements || !statements.length) return null;
 
-    return <Layout className="full" data-test-serial-coverage>{statements.map(this.renderStatement)}</Layout>;
+    return (
+      <Layout className="full" data-test-serial-coverage>
+        {statements.map(this.renderStatement)}
+      </Layout>
+    );
   }
 }


### PR DESCRIPTION
[This will hopefully alleviate some MCL column sizing issues as described in this thread.](https://folio-project.slack.com/archives/CAYCU07SN/p1583856407069400)

Also put in a fix for a bug I saw where the wrong translation ID was being used for internal contacts.