### PR TITLE
ERM-777: Allow deleting of agreements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-agreements
 
+##  3.5.0 IN PROGRESS
+* Added permission set and ability to delete agreements. ERM-777
+
 ##  3.4.1 2020-03-12
 * Set coverage columns to be fixed-width.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/agreements",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "ERM agreement functionality for Stripes",
   "main": "src/index.js",
   "publishConfig": {
@@ -160,6 +160,7 @@
       {
         "permissionName": "ui-agreements.agreements.delete",
         "displayName": "Agreements: Delete agreements",
+        "visible": true,
         "subPermissions": [
           "ui-agreements.agreements.view",
           "erm.agreements.item.delete"

--- a/src/components/Coverage/MonographCoverage.js
+++ b/src/components/Coverage/MonographCoverage.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { get } from 'lodash';
 import { Layout } from '@folio/stripes/components';
 
 export default class MonographCoverage extends React.Component {

--- a/src/components/DuplicateAgreementModal/DuplicateAgreementModal.js
+++ b/src/components/DuplicateAgreementModal/DuplicateAgreementModal.js
@@ -136,7 +136,7 @@ export default class DuplicateAgreementModal extends React.Component {
         dismissible
         footer={footer}
         id="duplicate-agreement"
-        label={<FormattedMessage id="ui-agreements.duplicateAgreement" />}
+        label={<FormattedMessage id="ui-agreements.agreements.duplicateAgreement" />}
         onClose={this.props.onClose}
         open
         size="small"

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -114,6 +114,19 @@ export default class Agreement extends React.Component {
     this.setState({ showDuplicateAgreementModal: false });
   }
 
+  handleSectionToggle = ({ id }) => {
+    this.setState((prevState) => ({
+      sections: {
+        ...prevState.sections,
+        [id]: !prevState.sections[id],
+      }
+    }));
+  }
+
+  handleAllSectionsToggle = (sections) => {
+    this.setState({ sections });
+  }
+
   getActionMenu = ({ onToggle }) => (
     <>
       <IfPermission perm="ui-agreements.agreements.edit">
@@ -286,7 +299,7 @@ export default class Agreement extends React.Component {
           heading={<FormattedMessage id="ui-agreements.agreements.deleteAgreement" />}
           id="delete-agreement-confirmation"
           message={<SafeHTMLMessage id="ui-agreements.agreements.deleteConfirmMessage" values={{ name: data.agreement?.name }} />}
-          onCancel={this.hideDeleteConfirmationModal}
+          onCancel={this.closeDeleteConfirmationModal}
           onConfirm={() => {
             handlers.onDelete();
             this.closeDeleteConfirmationModal();

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -7,6 +7,7 @@ import {
   AccordionSet,
   Button,
   Col,
+  ConfirmationModal,
   ExpandAllButton,
   Icon,
   IconButton,
@@ -17,6 +18,7 @@ import {
 import { AppIcon, IfPermission, TitleManager } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import { LoadingPane } from '@folio/stripes-erm-components';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import DuplicateAgreementModal from '../DuplicateAgreementModal';
 
 import {
@@ -48,8 +50,9 @@ export default class Agreement extends React.Component {
       searchString: PropTypes.string,
     }).isRequired,
     handlers: PropTypes.shape({
-      onClone: PropTypes.func,
+      onClone: PropTypes.func.isRequired,
       onClose: PropTypes.func.isRequired,
+      onDelete: PropTypes.func.isRequired,
       onEdit: PropTypes.func,
       onExportAgreement: PropTypes.func,
       onToggleTags: PropTypes.func,
@@ -59,6 +62,7 @@ export default class Agreement extends React.Component {
   }
 
   state = {
+    showDeleteConfirmationModal: false,
     showDuplicateAgreementModal: false,
     sections: {
       controllingLicense: false,
@@ -94,25 +98,20 @@ export default class Agreement extends React.Component {
     };
   }
 
+  openDeleteConfirmationModal = () => {
+    this.setState({ showDeleteConfirmationModal: true });
+  }
+
+  closeDeleteConfirmationModal = () => {
+    this.setState({ showDeleteConfirmationModal: false });
+  }
+
   openDuplicateAgreementModal = () => {
     this.setState({ showDuplicateAgreementModal: true });
   }
 
   closeDuplicateAgreementModal = () => {
     this.setState({ showDuplicateAgreementModal: false });
-  }
-
-  handleSectionToggle = ({ id }) => {
-    this.setState((prevState) => ({
-      sections: {
-        ...prevState.sections,
-        [id]: !prevState.sections[id],
-      }
-    }));
-  }
-
-  handleAllSectionsToggle = (sections) => {
-    this.setState({ sections });
   }
 
   getActionMenu = ({ onToggle }) => (
@@ -154,7 +153,20 @@ export default class Agreement extends React.Component {
           </Icon>
         </Button>
       </IfPermission>
-
+      <IfPermission perm="ui-agreements.agreements.delete">
+        <Button
+          buttonStyle="dropdownItem"
+          id="clickable-dropdown-delete-agreement"
+          onClick={() => {
+            this.openDeleteConfirmationModal();
+            onToggle();
+          }}
+        >
+          <Icon icon="trash">
+            <FormattedMessage id="ui-agreements.delete" />
+          </Icon>
+        </Button>
+      </IfPermission>
     </>
   )
 
@@ -205,6 +217,8 @@ export default class Agreement extends React.Component {
       handlers,
       helperApp
     } = this.props;
+
+    const { showDeleteConfirmationModal, showDuplicateAgreementModal } = this.state;
 
     if (isLoading) return <LoadingPane defaultWidth="60%" onClose={handlers.onClose} />;
 
@@ -259,12 +273,26 @@ export default class Agreement extends React.Component {
           </TitleManager>
         </Pane>
         {helperApp}
-        {this.state.showDuplicateAgreementModal &&
+        { showDuplicateAgreementModal &&
           <DuplicateAgreementModal
             onClone={(obj) => handlers.onClone(obj)}
             onClose={this.closeDuplicateAgreementModal}
           />
         }
+        <ConfirmationModal
+          buttonStyle="danger"
+          confirmLabel={<FormattedMessage id="ui-agreements.delete" />}
+          data-test-delete-confirmation-modal
+          heading={<FormattedMessage id="ui-agreements.agreements.deleteAgreement" />}
+          id="delete-agreement-confirmation"
+          message={<SafeHTMLMessage id="ui-agreements.agreements.deleteConfirmMessage" values={{ name: data.agreement?.name }} />}
+          onCancel={this.hideDeleteConfirmationModal}
+          onConfirm={() => {
+            handlers.onDelete();
+            this.closeDeleteConfirmationModal();
+          }}
+          open={showDeleteConfirmationModal}
+        />
       </>
 
     );

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -363,6 +363,7 @@ export default class Agreements extends React.Component {
                       columnWidths={this.columnWidths}
                       contentData={data.agreements}
                       formatter={this.formatter}
+                      hasMargin
                       id="list-agreements"
                       isEmptyMessage={this.renderIsEmptyMessage(query, source)}
                       isSelected={({ item }) => item.id === selectedRecordId}

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -23,7 +23,10 @@ class AgreementViewRoute extends React.Component {
     agreement: {
       type: 'okapi',
       path: 'erm/sas/:{id}',
-      shouldRefresh: () => false,
+      shouldRefresh: (resource, action) => {
+        if (resource.name !== 'agreement') return true;
+        return !action.meta.originatingActionType?.includes('DELETE');
+      },
     },
     agreementLines: {
       type: 'okapi',
@@ -312,25 +315,27 @@ class AgreementViewRoute extends React.Component {
     const agreement = this.getCompositeAgreement();
 
     if (agreement.items?.length) {
-      sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasAgreementLines" /> });
+      sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasAgreementLines" /> });
+      return;
     }
 
     if (agreement.linkedLicenses?.length) {
-      sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasLicenses" /> });
+      sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasLicenses" /> });
+      return;
     }
 
     if (agreement.relatedAgreements?.length) {
-      sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasRelatedAgreements" /> });
+      sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasRelatedAgreements" /> });
+      return;
     }
 
     mutator.agreement.DELETE(agreement)
       .then(() => {
-        // history.replace({ pathname: urls.agreements() });
         history.push(`${urls.agreements()}${location.search}`);
         sendCallout({ message: <SafeHTMLMessage id="ui-agreements.agreements.deletedAgreement" values={{ name : agreement.name }} /> });
       })
       .catch(error => {
-        sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteAgreementBackendError" values={{ message: error.message }} /> });
+        sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteAgreementBackendError" values={{ message: error.message }} /> });
       });
   }
 

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -23,6 +23,7 @@ class AgreementViewRoute extends React.Component {
     agreement: {
       type: 'okapi',
       path: 'erm/sas/:{id}',
+      shouldRefresh: () => false,
     },
     agreementLines: {
       type: 'okapi',
@@ -322,10 +323,11 @@ class AgreementViewRoute extends React.Component {
       sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasRelatedAgreements" /> });
     }
 
-    mutator.agreement.DELETE(agreement, { silent: true })
+    mutator.agreement.DELETE(agreement)
       .then(() => {
-        sendCallout({ message: <SafeHTMLMessage id="ui-agreements.agreements.deletedAgreement" values={{ name : agreement.name }} /> });
+        // history.replace({ pathname: urls.agreements() });
         history.push(`${urls.agreements()}${location.search}`);
+        sendCallout({ message: <SafeHTMLMessage id="ui-agreements.agreements.deletedAgreement" values={{ name : agreement.name }} /> });
       })
       .catch(error => {
         sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteAgreementBackendError" values={{ message: error.message }} /> });

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -322,9 +322,9 @@ class AgreementViewRoute extends React.Component {
       sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.errors.noDeleteHasRelatedAgreements" /> });
     }
 
-    mutator.agreement.DELETE()
+    mutator.agreement.DELETE(agreement, { silent: true })
       .then(() => {
-        sendCallout({ type: 'error', message: <SafeHTMLMessage id="ui-agreements.agreements.deletedAgreement" /> });
+        sendCallout({ message: <SafeHTMLMessage id="ui-agreements.agreements.deletedAgreement" values={{ name : agreement.name }} /> });
         history.push(`${urls.agreements()}${location.search}`);
       })
       .catch(error => {

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -10,7 +10,7 @@
   "notSet": "Not set",
   "saveAndClose": "Save & close",
   "dashboard": "Dashboard",
-  "duplicateAgreement": "Duplicate agreement",
+  "delete": "Delete",
   "agreements": "Agreements",
   "eresources": "E-resources",
   "selectAll": "Select all / deselect all",
@@ -26,7 +26,11 @@
 
   "note": "Note",
 
+  "agreements.deletedAgreement": "<strong>Agreement deleted:</strong> {name}",
+  "agreements.deleteAgreement": "Delete agreement",
+  "agreements.deleteConfirmMessage": "Agreement <strong>{name}</strong> will be <strong>deleted</strong>.",
   "agreements.duplicate": "Duplicate",
+  "agreements.duplicateAgreement": "Duplicate agreement",
   "agreements.edit": "Edit",
   "agreements.export": "Export",
   "agreements.showTags": "Show tags",
@@ -248,6 +252,10 @@
   "errors.overlappingPeriod": "The following periods have overlapping dates: {fields}",
   "errors.undefinedUDP": "A Usage Data Provider must be selected.",
   "errors.cannotLinkAgreementToItself": "An agreement cannot be linked to itself.",
+  "errors.noDeleteHasAgreementLines": "<strong>Agreement was not deleted</strong> because it has one or more agreement lines.",
+  "errors.noDeleteHasLicenses": "<strong>Agreement was not deleted</strong> because it has one or more licenses attached.",
+  "errors.noDeleteHasRelatedAgreements": "<strong>Agreement was not deleted</strong> because it has one or more related agreements.",
+  "errors.noDeleteAgreementBackendError": "<strong>Agreement was not deleted:</strong> {message}",
 
   "finances.none": "Agreement has no order lines.",
 


### PR DESCRIPTION
- Makes the `Agreements: Delete agreements` permission set visible and assignable.
- Adds `Delete` dropdown button
- Front-end checks for whether the agreement has lines, linked licenses, or related agreements. Disallows deletion if it does.
- Scoped `shouldRefresh` so that we don't attempt to try to fetch an `agreement` resource that was just deleted. Uses functionality added in https://github.com/folio-org/stripes-connect/pull/133