### PR TITLE
Add categories to Agreements supplementary documents, refs ERM-746

### DIFF
--- a/src/components/AgreementSections/FormSupplementaryDocuments.js
+++ b/src/components/AgreementSections/FormSupplementaryDocuments.js
@@ -8,6 +8,9 @@ import { DocumentsFieldArray } from '@folio/stripes-erm-components';
 
 export default class FormSupplementaryDocuments extends React.Component {
   static propTypes = {
+    data: PropTypes.shape({
+      documentCategories: PropTypes.array,
+    }).isRequired,
     handlers: PropTypes.shape({
       onDownloadFile: PropTypes.func.isRequired,
       onUploadFile: PropTypes.func.isRequired,
@@ -18,7 +21,7 @@ export default class FormSupplementaryDocuments extends React.Component {
   };
 
   render() {
-    const { id, handlers, onToggle, open } = this.props;
+    const { data, handlers, id, onToggle, open } = this.props;
     return (
       <Accordion
         id={id}
@@ -30,6 +33,7 @@ export default class FormSupplementaryDocuments extends React.Component {
           addDocBtnLabel={<FormattedMessage id="ui-agreements.supplementaryDocs.addSupplementaryDoc" />}
           component={DocumentsFieldArray}
           deleteBtnTooltipMsgId="ui-agreements.doc.removeSupplementaryInformation"
+          documentCategories={data.documentCategories}
           isEmptyMessage={<FormattedMessage id="ui-agreements.supplementaryDocs.agreementHasNone" />}
           name="supplementaryDocs"
           onDownloadFile={handlers.onDownloadFile}

--- a/src/routes/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute.js
@@ -45,6 +45,11 @@ class AgreementCreateRoute extends React.Component {
       path: 'erm/refdata/InternalContact/role',
       shouldRefresh: () => false,
     },
+    documentCategories: {
+      type: 'okapi',
+      path: 'erm/refdata/DocumentAttachment/atType',
+      shouldRefresh: () => false,
+    },
     externalAgreementLine: {
       type: 'okapi',
       path: 'erm/entitlements/external',
@@ -211,6 +216,7 @@ class AgreementCreateRoute extends React.Component {
           basket: (resources?.basket ?? []),
           supplementaryProperties: (resources?.supplementaryProperties?.records ?? []),
           contactRoleValues: (resources?.contactRoleValues?.records ?? []),
+          documentCategories: (resources?.documentCategories?.records ?? []),
           isPerpetualValues: (resources?.isPerpetualValues?.records ?? []),
           licenseLinkStatusValues: (resources?.licenseLinkStatusValues?.records ?? []),
           orgRoleValues: (resources?.orgRoleValues?.records ?? []),

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { cloneDeep, get } from 'lodash';
+import { cloneDeep } from 'lodash';
 import compose from 'compose-function';
 
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
@@ -54,6 +54,11 @@ class AgreementEditRoute extends React.Component {
       path: 'erm/refdata/InternalContact/role',
       shouldRefresh: () => false,
     },
+    documentCategories: {
+      type: 'okapi',
+      path: 'erm/refdata/DocumentAttachment/atType',
+      shouldRefresh: () => false,
+    },
     isPerpetualValues: {
       type: 'okapi',
       path: 'erm/refdata/SubscriptionAgreement/isPerpetual',
@@ -68,7 +73,7 @@ class AgreementEditRoute extends React.Component {
       type: 'okapi',
       path: 'orders/order-lines',
       params: (_q, _p, _r, _l, props) => {
-        const query = get(props.resources, 'agreementLines.records', [])
+        const query = (props?.resources?.agreementLines?.records ?? [])
           .filter(line => line.poLines && line.poLines.length)
           .map(line => (line.poLines
             .map(poLine => `id==${poLine.poLineId}`)
@@ -100,7 +105,7 @@ class AgreementEditRoute extends React.Component {
       type: 'okapi',
       path: 'users',
       params: (_q, _p, _r, _l, props) => {
-        const query = get(props.resources, 'agreement.records[0].contacts', [])
+        const query = (props?.resources?.agreement?.records?.[0]?.contacts ?? [])
           .filter(contact => contact.user)
           .map(contact => `id==${contact.user}`)
           .join(' or ');
@@ -173,7 +178,7 @@ class AgreementEditRoute extends React.Component {
   static getDerivedStateFromProps(props, state) {
     let updated = false;
 
-    const agreement = get(props.resources, 'agreement.records[0]', {});
+    const agreement = props?.resources?.agreement?.records?.[0] ?? {};
 
     // Start with the existing initialValues. However, if we've just fetched a new agreement
     // then use that as the baseline. This would be the case if we didn't have an agreement in
@@ -213,7 +218,8 @@ class AgreementEditRoute extends React.Component {
         // Init the list of amendments based on the license's amendments to ensure
         // we display those that have been created since this agreement's license was last
         // edited. Ensure we provide defaults via amendmentId.
-        amendments: get(l, 'remoteId_object.amendments', [])
+        // eslint-disable-next-line camelcase
+        amendments: (l?.remoteId_object?.amendments ?? [])
           .map(a => {
             const assignedAmendment = (l.amendments || []).find(la => la.amendmentId === a.id) || {};
             return {
@@ -226,7 +232,7 @@ class AgreementEditRoute extends React.Component {
 
       // Add the default supplementaryProperties to the already-set supplementaryProperties.
       initialValues.customProperties = initialValues.customProperties || {};
-      const supplementaryProperties = get(props.resources, 'supplementaryProperties.records', []);
+      const supplementaryProperties = (props?.resources?.supplementaryProperties?.records ?? []);
       supplementaryProperties
         .filter(t => t.primary && initialValues.customProperties[t.name] === undefined)
         .forEach(t => { initialValues.customProperties[t.name] = ''; });
@@ -236,7 +242,7 @@ class AgreementEditRoute extends React.Component {
       )(initialValues);
     }
 
-    const lines = get(props.resources, 'agreementLines.records', []);
+    const lines = (props?.resources?.agreementLines?.records ?? []);
     if (items.length && lines.length && (lines[0].owner.id === props.match.params.id)) {
       updated = true;
 
@@ -293,7 +299,7 @@ class AgreementEditRoute extends React.Component {
 
   getAgreementLines = () => {
     return [
-      ...get(this.props.resources, 'agreementLines.records', []),
+      ...(this.props.resources?.agreementLines?.records ?? []),
       ...this.getAgreementLinesToAdd(),
     ];
   }
@@ -302,11 +308,11 @@ class AgreementEditRoute extends React.Component {
     const { resources } = this.props;
     const { query: { addFromBasket } } = resources;
 
-    const externalAgreementLines = get(resources, 'externalAgreementLine.records', []);
+    const externalAgreementLines = resources?.externalAgreementLine?.records ?? [];
 
     let basketLines = [];
     if (resources.query.addFromBasket) {
-      const basket = get(resources, 'basket', []);
+      const basket = resources?.basket ?? [];
 
       basketLines = addFromBasket
         .split(',')
@@ -337,19 +343,20 @@ class AgreementEditRoute extends React.Component {
         data={{
           agreementLines: this.getAgreementLines(),
           agreementLinesToAdd: this.getAgreementLinesToAdd(),
-          agreementStatusValues: get(resources, 'agreementStatusValues.records', []),
-          reasonForClosureValues: get(resources, 'reasonForClosureValues.records', []),
-          amendmentStatusValues: get(resources, 'amendmentStatusValues.records', []),
-          basket: get(resources, 'basket', []),
-          contactRoleValues: get(resources, 'contactRoleValues.records', []),
-          externalAgreementLine: get(resources, 'externalAgreementLine.records', []),
-          isPerpetualValues: get(resources, 'isPerpetualValues.records', []),
-          licenseLinkStatusValues: get(resources, 'licenseLinkStatusValues.records', []),
-          orderLines: get(resources, 'orderLines.records', []),
-          orgRoleValues: get(resources, 'orgRoleValues.records', []),
-          renewalPriorityValues: get(resources, 'renewalPriorityValues.records', []),
-          supplementaryProperties: get(resources, 'supplementaryProperties.records', []),
-          users: get(resources, 'users.records', []),
+          agreementStatusValues: resources?.agreementStatusValues?.records ?? [],
+          reasonForClosureValues: resources?.reasonForClosureValues?.records ?? [],
+          amendmentStatusValues: resources?.amendmentStatusValues?.records ?? [],
+          basket: resources?.basket ?? [],
+          contactRoleValues: resources?.contactRoleValues?.records ?? [],
+          documentCategories: resources?.documentCategories?.records ?? [],
+          externalAgreementLine: resources?.externalAgreementLine?.records ?? [],
+          isPerpetualValues: resources?.isPerpetualValues?.records ?? [],
+          licenseLinkStatusValues: resources?.licenseLinkStatusValues?.records ?? [],
+          orderLines: resources?.orderLines?.records ?? [],
+          orgRoleValues: resources?.orgRoleValues?.records ?? [],
+          renewalPriorityValues: resources?.renewalPriorityValues?.records ?? [],
+          supplementaryProperties: resources?.supplementaryProperties?.records ?? [],
+          users: resources?.users?.records ?? [],
         }}
         handlers={{
           ...handlers,


### PR DESCRIPTION
- Fetches documentCategories from the `erm/refdata/DocumentAttachment/atType` endpoint
- Also cleaned up the lodash `get`s in `AgreementEditRoute`