### PR TITLE
ERM-921 ERM-922: AgLine coverage bug fixes

### DIFF
--- a/src/components/AgreementLineSections/Coverage.js
+++ b/src/components/AgreementLineSections/Coverage.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge, MultiColumnList } from '@folio/stripes/components';
+import {
+  Accordion,
+  Badge,
+  FormattedUTCDate,
+  MultiColumnList
+} from '@folio/stripes/components';
 
 import CustomCoverageIcon from '../CustomCoverageIcon';
 import Embargo from '../Embargo';
@@ -69,8 +74,8 @@ const Coverage = ({
               :
               ''
           ),
-          endDate: c => (c.startDate ? <FormattedDate value={c.endDate} /> : ''),
-          startDate: c => (c.startDate ? <FormattedDate value={c.startDate} /> : ''),
+          endDate: c => (c.endDate ? <FormattedUTCDate value={c.endDate} /> : ''),
+          startDate: c => (c.startDate ? <FormattedUTCDate value={c.startDate} /> : ''),
         }}
         interactive={false}
         isEmptyMessage={<FormattedMessage id="ui-agreements.emptyAccordion.lineCoverage" />}

--- a/src/routes/AgreementLineEditRoute.js
+++ b/src/routes/AgreementLineEditRoute.js
@@ -80,6 +80,15 @@ class AgreementLineEditRoute extends React.Component {
     };
   }
 
+  getInitialValues = () => {
+    const line = this.props.resources.line?.records?.[0];
+
+    return {
+      ...line,
+      coverage: line.customCoverage ? line.coverage : undefined,
+    };
+  }
+
   handleClose = () => {
     const {
       history,
@@ -126,7 +135,7 @@ class AgreementLineEditRoute extends React.Component {
         handlers={{
           onClose: this.handleClose,
         }}
-        initialValues={resources.line?.records?.[0]}
+        initialValues={this.getInitialValues()}
         isLoading={this.isLoading()}
         onSubmit={this.handleSubmit}
       />


### PR DESCRIPTION
ERM-921
- Switched to using `FormattedUTCDate` and fixed a c/p error.

ERM-922
- Only passed `coverage` along as part of `initialValues` if the `customCoverage` flag was set.
- We already use this approach when editing the agreement itself.