### PR TITLE
ERM-924: Added confirmation when deleting agline

### DIFF
--- a/src/components/views/AgreementLine.js
+++ b/src/components/views/AgreementLine.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -7,6 +7,7 @@ import {
   AccordionStatus,
   Button,
   Col,
+  ConfirmationModal,
   ExpandAllButton,
   Icon,
   IconButton,
@@ -17,6 +18,7 @@ import {
 } from '@folio/stripes/components';
 import { AppIcon, IfPermission } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import { Info, POLines, Coverage } from '../AgreementLineSections';
 import { isExternal, urls } from '../utilities';
@@ -67,10 +69,12 @@ const AgreementLine = ({
   };
 
   const intl = useIntl();
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState(false);
 
   if (isLoading) return <LoadingPane data-loading {...paneProps} />;
 
   const resource = isExternal(line) ? line : (line.resource?._object ?? {});
+  const resourceName = resource.pti?.titleInstance.name ?? resource.reference_object?.label ?? '';
 
   return (
     <>
@@ -89,7 +93,7 @@ const AgreementLine = ({
             <Button
               buttonStyle="dropdownItem"
               id="clickable-dropdown-delete-agreement-line"
-              onClick={handlers.onDelete}
+              onClick={() => setShowDeleteConfirmationModal(true)}
             >
               <Icon icon="trash">
                 <FormattedMessage id="ui-agreements.delete" />
@@ -112,7 +116,7 @@ const AgreementLine = ({
               }
             </PaneMenu>
           </IfPermission>
-      }
+        }
         paneTitle={<FormattedMessage id="ui-agreements.agreementLine" />}
         {...paneProps}
       >
@@ -143,6 +147,20 @@ const AgreementLine = ({
         </AccordionStatus>
       </Pane>
       {helperApp}
+      <ConfirmationModal
+        buttonStyle="danger"
+        confirmLabel={<FormattedMessage id="ui-agreements.delete" />}
+        data-test-delete-confirmation-modal
+        heading={<FormattedMessage id="ui-agreements.agreementLines.deleteAgreementLine" />}
+        id="delete-agreement-line-confirmation"
+        message={<SafeHTMLMessage id="ui-agreements.agreementLines.deleteConfirmMessage" values={{ name: resourceName }} />}
+        onCancel={() => setShowDeleteConfirmationModal(false)}
+        onConfirm={() => {
+          handlers.onDelete();
+          setShowDeleteConfirmationModal(false);
+        }}
+        open={showDeleteConfirmationModal}
+      />
     </>
   );
 };

--- a/src/routes/AgreementLineViewRoute.js
+++ b/src/routes/AgreementLineViewRoute.js
@@ -5,7 +5,8 @@ import compose from 'compose-function';
 
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
-import { preventResourceRefresh, Tags } from '@folio/stripes-erm-components';
+import { Tags } from '@folio/stripes-erm-components';
+
 import View from '../components/views/AgreementLine';
 import { urls } from '../components/utilities';
 
@@ -19,7 +20,7 @@ class AgreementLineViewRoute extends React.Component {
     line: {
       type: 'okapi',
       path: 'erm/entitlements/:{lineId}',
-      shouldRefresh: preventResourceRefresh({ line: ['DELETE'] }),
+      throwErrors: false,
     },
     orderLines: {
       type: 'okapi',
@@ -33,7 +34,6 @@ class AgreementLineViewRoute extends React.Component {
       },
       fetch: props => !!props.stripes.hasInterface('order-lines', '1.0'),
       records: 'poLines',
-      shouldRefresh: preventResourceRefresh({ line: ['DELETE'] }),
       throwErrors: false,
     },
     query: {},
@@ -127,7 +127,7 @@ class AgreementLineViewRoute extends React.Component {
       items: [{ id: lineId, _delete: true }]
     })
       .then(() => {
-        history.push(`${urls.agreements()}${location.search}`);
+        history.push(`${urls.agreementView(agreementId)}${location.search}`);
         sendCallout({ message: <FormattedMessage id="ui-agreements.line.delete.callout" /> });
       })
       .catch(error => {

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -104,6 +104,8 @@
   "agreementLines.costType": "Cost type",
   "agreementLines.count": "Count",
   "agreementLines.contentUpdated": "Content updated",
+  "agreementLines.deleteAgreementLine": "Delete agreement line",
+  "agreementLines.deleteConfirmMessage": "Agreement line for the e-resource <strong>{name}</strong> will be <strong>deleted</strong>.",
   "agreementLines.gross": "YTD Gross",
   "agreementLines.net": "YTD Net",
   "agreementLines.noLines": "Agreement has no agreement lines.",


### PR DESCRIPTION
Needed to add some `throwErrors: false`. We don't want to turn off resource-refreshing because the deletion occurs via a PUT.