### PR TITLE
ERM-938 ERM-939: Show Embargo info on AgLine pages

### DIFF
--- a/src/components/AgreementLineSections/Coverage.js
+++ b/src/components/AgreementLineSections/Coverage.js
@@ -6,6 +6,7 @@ import {
   Accordion,
   Badge,
   FormattedUTCDate,
+  KeyValue,
   MultiColumnList
 } from '@folio/stripes/components';
 
@@ -39,7 +40,13 @@ const Coverage = ({
       id="agreement-line-coverage"
       label={<FormattedMessage id="ui-agreements.eresources.coverage" />}
     >
-      <Embargo embargo={resource?.embargo} />
+      { resource?.embargo ?
+        <KeyValue label={<FormattedMessage id="ui-agreements.embargo" />}>
+          <Embargo embargo={resource?.embargo} />
+        </KeyValue>
+        :
+        null
+      }
       <MultiColumnList
         columnMapping={{
           startDate: <FormattedMessage id="ui-agreements.agreements.startDate" />,
@@ -62,17 +69,14 @@ const Coverage = ({
         contentData={line.coverage}
         formatter={{
           customCoverage: () => (
-            line.customCoverage
-              ?
-              (
-                <>
-                  <FormattedMessage id="ui-agreements.agreementLines.custom" />
-                  &nbsp;
-                  <CustomCoverageIcon />
-                </>
-              )
+            line.customCoverage ?
+              <>
+                <FormattedMessage id="ui-agreements.agreementLines.custom" />
+                &nbsp;
+                <CustomCoverageIcon />
+              </>
               :
-              ''
+              <FormattedMessage id="ui-agreements.agreementLines.custom" />
           ),
           endDate: c => (c.endDate ? <FormattedUTCDate value={c.endDate} /> : ''),
           startDate: c => (c.startDate ? <FormattedUTCDate value={c.startDate} /> : ''),

--- a/src/components/AgreementLineSections/Coverage.js
+++ b/src/components/AgreementLineSections/Coverage.js
@@ -76,7 +76,7 @@ const Coverage = ({
                 <CustomCoverageIcon />
               </>
               :
-              <FormattedMessage id="ui-agreements.agreementLines.custom" />
+              <FormattedMessage id="ui-agreements.default" />
           ),
           endDate: c => (c.endDate ? <FormattedUTCDate value={c.endDate} /> : ''),
           startDate: c => (c.startDate ? <FormattedUTCDate value={c.startDate} /> : ''),

--- a/src/components/AgreementLineSections/FormCoverage.js
+++ b/src/components/AgreementLineSections/FormCoverage.js
@@ -6,6 +6,7 @@ import { Accordion, Col, KeyValue, Layout, Row } from '@folio/stripes/components
 
 import { SerialCoverage } from '../Coverage';
 import CoverageFieldArray from '../CoverageFieldArray';
+import Embargo from '../Embargo';
 import { isExternal, isPackage } from '../utilities';
 
 const propTypes = {
@@ -26,6 +27,15 @@ const FormCoverage = ({
       label={<FormattedMessage id="ui-agreements.eresources.coverage" />}
     >
       <Row>
+        { resource?.embargo ?
+          <Col xs={4}>
+            <KeyValue label={<FormattedMessage id="ui-agreements.embargo" />}>
+              <Embargo embargo={resource?.embargo} />
+            </KeyValue>
+          </Col>
+          :
+          null
+        }
         <Col xs={4}>
           <KeyValue
             label={(

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -15,6 +15,8 @@
   "eresources": "E-resources",
   "status": "Status",
 
+  "default": "Default",
+
   "agreement": "Agreement",
   "agreementPluralizable": "{count} {count, plural, one {agreement} other {agreements}}",
   "agreementLinePluralizable": "{count} {count, plural, one {agreement line} other {agreement lines}}",


### PR DESCRIPTION
- Show Embargo details when viewing/editing an agreement line
- AgLine View: Show `Default` for coverage type in default coverage rows.