### PR TITLE
Set keys for RelatedTitleInfo

### DIFF
--- a/src/components/TitleCard/TitleCardInfo.js
+++ b/src/components/TitleCard/TitleCardInfo.js
@@ -31,9 +31,9 @@ const TitleCardInfo = ({ title }) => {
         <MonographResourceInfo titleInstance={titleInstance} />
         :
         <SerialResourceInfo titleInstance={titleInstance} />
-  }
-      { titleInstance?.relatedTitles?.map((relatedTitle) => (
-        <RelatedTitleInfo relatedTitle={relatedTitle} />
+      }
+      { titleInstance?.relatedTitles?.map((relatedTitle, i) => (
+        <RelatedTitleInfo key={i} relatedTitle={relatedTitle} />
       ))
       }
     </>


### PR DESCRIPTION
React complains on the console when a key is not set for array elements because it's required to set one.