### PR TITLE
refs ERM-1120 ERM-1130

### DIFF
--- a/src/components/Coverage/MonographCoverage.js
+++ b/src/components/Coverage/MonographCoverage.js
@@ -46,7 +46,7 @@ export default class MonographCoverage extends React.Component {
     const edition = pci?.pti?.titleInstance?.monographEdition;
 
     if (!date && !volume && !edition) {
-      return '*';
+      return null;
     }
 
     return (

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -449,7 +449,7 @@
   "relatedAgreements.noPlugin": "No \"find-agreement\" plugin is installed",
   "relatedAgreements.relatedAgreementIndex": "Related agreement {index}",
   "relatedAgreements.relationship.has_backfile_in": "Has backfile in \"{agreement}\"",
-  "relatedAgreements.relationship.has_frontfile_in": "Has frontile in \"{agreement}\"",
+  "relatedAgreements.relationship.has_frontfile_in": "Has frontfile in \"{agreement}\"",
   "relatedAgreements.relationship.has-demand-driven-acquisitions-in": "Has demand-driven acquisitions in \"{agreement}\"",
   "relatedAgreements.relationship.has-post-cancellation-access-in": "Has post-cancellation access in \"{agreement}\"",
   "relatedAgreements.relationship.is-superseded-by": "Is superseded by \"{agreement}\"",

--- a/translations/ui-agreements/en_US.json
+++ b/translations/ui-agreements/en_US.json
@@ -431,7 +431,7 @@
     "eresources.titleOnPlatform": "Title on platform",
     "eresources.accessTitleOnPlatform": "Access {name}",
     "relatedAgreements.relationship.has_backfile_in": "Has backfile in \"{agreement}\"",
-    "relatedAgreements.relationship.has_frontfile_in": "Has frontile in \"{agreement}\"",
+    "relatedAgreements.relationship.has_frontfile_in": "Has frontfile in \"{agreement}\"",
     "relatedAgreements.relationship.related_to": "Related to \"{agreement}\"",
     "relatedAgreements.relationship.related_to_inward": "Related to \"{agreement}\"",
     "org.olf.erm.SubscriptionAgreement.name.unique": "This name already exists",


### PR DESCRIPTION
* return null instead of * for monograph w/o coverage in MonographCoverage
* fix typo for 'relatedAgreements.relationship.has_frontfile_in' in en.json and en_US.json