### PR TITLE
STCOM-770 Add duplicateRecord handler

### DIFF
--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -269,7 +269,6 @@ class Agreement extends React.Component {
         name: 'duplicateRecord',
         handler: (e) => {
           this.openDuplicateAgreementModal();
-          onToggle();
         }
       }
     ];

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -264,6 +264,13 @@ class Agreement extends React.Component {
       {
         name: 'collapseAllSections',
         handler: (e) => collapseAllSections(e, this.accordionStatusRef)
+      },
+      {
+        name: 'duplicateRecord',
+        handler: (e) => {
+          this.openDuplicateAgreementModal();
+          onToggle();
+        }
       }
     ];
 


### PR DESCRIPTION
Added a keyboard shortcut  (`alt + c`) to which can be used to duplicate a record if document focus is within a record's view. (anywhere in the detail pane.)