### PR TITLE
keyboard shortcut cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added optionalOkapiInterfaces to package.json. ERM-940
 * Rename instance-bulk to inventory-record-bulk. UIIN-1368
 * Upgrade to Stripes 6.0
+* Modify keyboard shortcuts, use handlers from stripes-components, stripes-erm-components
 ##  5.0.1 2020-11-05
 * Added permission check when displaying the add agreement line button. ERM-1197
 * Fixes bug where incorrect Dates are saved when tenant timezone is ahead of UTC. ERM-1202

--- a/src/components/NoPermissions/NoPermissions.test.js
+++ b/src/components/NoPermissions/NoPermissions.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@folio/stripes-erm-components/test/jest/__mock__';
-import { renderWithIntl, TestForm } from '@folio/stripes-erm-components/test/jest/helpers';
+import { renderWithIntl } from '@folio/stripes-erm-components/test/jest/helpers';
 import NoPermissions from './NoPermissions';
 import translationsProperties from '../../../test/helpers';
 

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -16,11 +16,13 @@ import {
   Pane,
   PaneMenu,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import { AppIcon, IfPermission, TitleManager, withStripes } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 import DuplicateAgreementModal from '../DuplicateAgreementModal';
 
 import {

--- a/src/components/views/AgreementForm.js
+++ b/src/components/views/AgreementForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get, isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import setFieldData from 'final-form-set-field-data';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
+import { handleSaveKeyCommand } from '@folio/stripes-erm-components';
 import { AppIcon, IfPermission, TitleManager } from '@folio/stripes/core';
 
 import {
@@ -19,6 +19,9 @@ import {
   PaneMenu,
   Paneset,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -124,20 +127,6 @@ class AgreementForm extends React.Component {
     };
   }
 
-  handleSaveKeyCommand = (e) => {
-    const {
-      handleSubmit,
-      pristine,
-      submitting,
-    } = this.props;
-
-    e.preventDefault();
-
-    if (!pristine && !submitting) {
-      handleSubmit();
-    }
-  }
-
   renderPaneFooter() {
     const {
       handlers,
@@ -195,7 +184,7 @@ class AgreementForm extends React.Component {
   shortcuts = [
     {
       name: 'save',
-      handler: this.handleSaveKeyCommand,
+      handler: (e) => handleSaveKeyCommand(e, this.props),
     },
     {
       name: 'expandAllSections',

--- a/src/components/views/AgreementLine.js
+++ b/src/components/views/AgreementLine.js
@@ -17,11 +17,13 @@ import {
   Pane,
   PaneMenu,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 
 import { Info, POLines, Coverage } from '../AgreementLineSections';
 import { isExternal, urls } from '../utilities';

--- a/src/components/views/AgreementLineForm.js
+++ b/src/components/views/AgreementLineForm.js
@@ -1,9 +1,9 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty, isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import setFieldData from 'final-form-set-field-data';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
+import { handleSaveKeyCommand } from '@folio/stripes-erm-components';
 
 import {
   AccordionSet,
@@ -17,6 +17,9 @@ import {
   PaneFooter,
   Paneset,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 
 import { AppIcon } from '@folio/stripes/core';
@@ -73,23 +76,11 @@ const AgreementLineForm = ({
   const [agreementLineSource, setAgreementLineSource] = useState('basket');
 
   const accordionStatusRef = useRef();
-  const isFormSubmittableRef = useRef(false);
-
-  useEffect(() => {
-    isFormSubmittableRef.current = !pristine && !submitting;
-  }, [pristine, submitting]);
-
-  const handleSaveKeyCommand = (e) => {
-    e.preventDefault();
-    if (isFormSubmittableRef.current) {
-      handleSubmit();
-    }
-  };
 
   const shortcuts = [
     {
       name: 'save',
-      handler: handleSaveKeyCommand
+      handler: (e) => handleSaveKeyCommand(e, { handleSubmit, pristine, submitting }),
     },
     {
       name: 'expandAllSections',

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -13,6 +13,7 @@ import {
   Pane,
   PaneMenu,
   SearchField,
+  checkScope
 } from '@folio/stripes/components';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
@@ -42,7 +43,6 @@ const propTypes = {
     supplementaryProperties: PropTypes.arrayOf(PropTypes.object).isRequired,
     tagsValues: PropTypes.arrayOf(PropTypes.object).isRequired,
   }),
-  handlers: PropTypes.object,
   history: PropTypes.object,
   onNeedMoreData: PropTypes.func.isRequired,
   queryGetter: PropTypes.func.isRequired,
@@ -59,7 +59,6 @@ const filterPaneVisibilityKey = '@folio/agreements/agreementsFilterPaneVisibilit
 const Agreements = ({
   children,
   data = {},
-  handlers,
   history,
   onNeedMoreData,
   queryGetter,
@@ -95,7 +94,7 @@ const Agreements = ({
   return (
     <HasCommand
       commands={shortcuts}
-      isWithinScope={handlers.checkScope}
+      isWithinScope={checkScope}
       scope={document.body}
     >
       <div data-test-agreements>

--- a/src/components/views/Agreements.js
+++ b/src/components/views/Agreements.js
@@ -81,7 +81,7 @@ const Agreements = ({
   };
 
   const goToNew = () => {
-    history.push('/erm/agreements/create');
+    history.push(`${urls.agreementCreate()}${searchString}`);
   };
 
   const shortcuts = [

--- a/src/components/views/PCI.js
+++ b/src/components/views/PCI.js
@@ -10,6 +10,9 @@ import {
   HasCommand,
   Headline,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import DiscoverySettings from '../DiscoverySettings';
 
@@ -39,9 +42,6 @@ export default class PCI extends React.Component {
       settings: PropTypes.object,
     }),
     handlers: PropTypes.shape({
-      checkScope: PropTypes.func.isRequired,
-      collapseAllSections: PropTypes.func.isRequired,
-      expandAllSections: PropTypes.func.isRequired,
       isSuppressFromDiscoveryEnabled: PropTypes.func.isRequired,
       onEdit: PropTypes.func.isRequired,
       onNeedMoreEntitlements: PropTypes.func.isRequired,
@@ -72,18 +72,18 @@ export default class PCI extends React.Component {
       },
       {
         name: 'expandAllSections',
-        handler: (e) => handlers.expandAllSections(e, this.accordionStatusRef),
+        handler: (e) => expandAllSections(e, this.accordionStatusRef),
       },
       {
         name: 'collapseAllSections',
-        handler: (e) => handlers.collapseAllSections(e, this.accordionStatusRef)
+        handler: (e) => collapseAllSections(e, this.accordionStatusRef)
       }
     ];
 
     return (
       <HasCommand
         commands={shortcuts}
-        isWithinScope={handlers.checkScope}
+        isWithinScope={checkScope}
         scope={document.body}
       >
         <div id="eresource-pci">

--- a/src/components/views/PCIForm.js
+++ b/src/components/views/PCIForm.js
@@ -15,10 +15,13 @@ import {
   PaneMenu,
   Paneset,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import { TitleManager } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
+import { handleSaveKeyCommand } from '@folio/stripes-erm-components';
 import css from './PCIForm.css';
 
 import { PCIFormCoverage, PCIFormInfo } from '../EResourceSections';
@@ -62,20 +65,6 @@ class PCIForm extends React.Component {
       id,
       values,
     };
-  }
-
-  handleSaveKeyCommand = (e) => {
-    const {
-      handleSubmit,
-      pristine,
-      submitting,
-    } = this.props;
-
-    e.preventDefault();
-
-    if (!pristine && !submitting) {
-      handleSubmit();
-    }
   }
 
   renderPaneFooter() {
@@ -134,7 +123,7 @@ class PCIForm extends React.Component {
   shortcuts = [
     {
       name: 'save',
-      handler: this.handleSaveKeyCommand,
+      handler: (e) => handleSaveKeyCommand(e, this.props),
     },
     {
       name: 'expandAllSections',

--- a/src/components/views/Package.js
+++ b/src/components/views/Package.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 
 import {
   AccordionSet,
@@ -10,6 +9,9 @@ import {
   ExpandAllButton,
   HasCommand,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 

--- a/src/components/views/Platform.js
+++ b/src/components/views/Platform.js
@@ -13,7 +13,9 @@ import {
   LoadingPane,
   Row,
   Pane,
-  checkScope
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import { AppIcon, TitleManager, useStripes } from '@folio/stripes/core';
 import { PlatformInfo, PlatformUrlCustomization, PlatformProxySettings } from '../PlatformSections';
@@ -57,6 +59,14 @@ const Platform = ({
     {
       name: 'edit',
       handler: handlers.onEdit,
+    },
+    {
+      name: 'expandAllSections',
+      handler: (e) => expandAllSections(e, accordionStatusRef),
+    },
+    {
+      name: 'collapseAllSections',
+      handler: (e) => collapseAllSections(e, accordionStatusRef)
     },
   ];
 

--- a/src/components/views/Platform.js
+++ b/src/components/views/Platform.js
@@ -1,7 +1,6 @@
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { checkScope } from '@folio/stripes-erm-components';
 
 import {
   AccordionSet,
@@ -14,6 +13,7 @@ import {
   LoadingPane,
   Row,
   Pane,
+  checkScope
 } from '@folio/stripes/components';
 import { AppIcon, TitleManager, useStripes } from '@folio/stripes/core';
 import { PlatformInfo, PlatformUrlCustomization, PlatformProxySettings } from '../PlatformSections';

--- a/src/components/views/PlatformForm.js
+++ b/src/components/views/PlatformForm.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { checkScope } from '@folio/stripes-erm-components';
+import { handleSaveKeyCommand } from '@folio/stripes-erm-components';
 
 import {
   Button,
@@ -12,6 +12,7 @@ import {
   PaneFooter,
   PaneMenu,
   Paneset,
+  checkScope
 } from '@folio/stripes/components';
 
 import { AppIcon, TitleManager } from '@folio/stripes/core';
@@ -25,23 +26,10 @@ const PlatformForm = ({
   submitting,
   values: { name }
 }) => {
-  const isFormSubmittableRef = useRef(false);
-
-  useEffect(() => {
-    isFormSubmittableRef.current = !pristine && !submitting;
-  }, [pristine, submitting]);
-
-  const handleSaveKeyCommand = (e) => {
-    e.preventDefault();
-    if (isFormSubmittableRef.current) {
-      handleSubmit();
-    }
-  };
-
   const shortcuts = [
     {
       name: 'save',
-      handler: handleSaveKeyCommand
+      handler: (e) => handleSaveKeyCommand(e, { handleSubmit, pristine, submitting }),
     },
   ];
 

--- a/src/components/views/Title.js
+++ b/src/components/views/Title.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 
 import {
   AccordionSet,
@@ -11,6 +10,9 @@ import {
   HasCommand,
   Headline,
   Row,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import DiscoverySettings from '../DiscoverySettings';

--- a/src/components/views/TitleForm.js
+++ b/src/components/views/TitleForm.js
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import { checkScope } from '@folio/stripes-erm-components';
+import { handleSaveKeyCommand } from '@folio/stripes-erm-components';
 
 import {
   Button,
@@ -12,6 +12,7 @@ import {
   PaneFooter,
   PaneMenu,
   Paneset,
+  checkScope
 } from '@folio/stripes/components';
 
 import { AppIcon, TitleManager } from '@folio/stripes/core';
@@ -30,19 +31,6 @@ const TitleForm = ({
   submitting,
   values,
 }) => {
-  const isFormSubmittableRef = useRef(false);
-
-  useEffect(() => {
-    isFormSubmittableRef.current = !pristine && !submitting;
-  }, [pristine, submitting]);
-
-  const handleSaveKeyCommand = (e) => {
-    e.preventDefault();
-    if (isFormSubmittableRef.current) {
-      handleSubmit();
-    }
-  };
-
   const getSectionProps = () => {
     return {
       form,
@@ -56,7 +44,7 @@ const TitleForm = ({
   const shortcuts = [
     {
       name: 'save',
-      handler: handleSaveKeyCommand
+      handler: (e) => handleSaveKeyCommand(e, { handleSubmit, pristine, submitting }),
     },
   ];
 

--- a/src/components/views/UrlCustomizer.js
+++ b/src/components/views/UrlCustomizer.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { checkScope } from '@folio/stripes-erm-components';
 
 import {
   Button,
@@ -15,6 +14,7 @@ import {
   NoValue,
   Row,
   Pane,
+  checkScope
 } from '@folio/stripes/components';
 import { TitleManager, useStripes } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';

--- a/src/components/views/UrlCustomizerForm.js
+++ b/src/components/views/UrlCustomizerForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 import setFieldData from 'final-form-set-field-data';
-import { checkScope, collapseAllSections, expandAllSections, composeValidators, requiredValidator } from '@folio/stripes-erm-components';
+import { composeValidators, handleSaveKeyCommand, requiredValidator } from '@folio/stripes-erm-components';
 import { TitleManager } from '@folio/stripes/core';
 import { Field } from 'react-final-form';
 
@@ -20,7 +20,10 @@ import {
   Paneset,
   Row,
   TextArea,
-  TextField
+  TextField,
+  checkScope,
+  collapseAllSections,
+  expandAllSections
 } from '@folio/stripes/components';
 
 import stripesFinalForm from '@folio/stripes/final-form';
@@ -38,20 +41,6 @@ class UrlCustomizerForm extends React.Component {
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
     values: PropTypes.object,
-  }
-
-  handleSaveKeyCommand = (e) => {
-    const {
-      handleSubmit,
-      pristine,
-      submitting,
-    } = this.props;
-
-    e.preventDefault();
-
-    if (!pristine && !submitting) {
-      handleSubmit();
-    }
   }
 
   renderPaneFooter() {
@@ -111,7 +100,7 @@ class UrlCustomizerForm extends React.Component {
   shortcuts = [
     {
       name: 'save',
-      handler: this.handleSaveKeyCommand,
+      handler: (e) => handleSaveKeyCommand(e, this.props),
     },
     {
       name: 'expandAllSections',

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,14 @@ import React, { lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { Switch } from 'react-router-dom';
 import { Route } from '@folio/stripes/core';
-import { CommandList, HasCommand, Layout } from '@folio/stripes/components';
+import {
+  CommandList,
+  HasCommand,
+  Layout,
+  checkScope,
+  defaultKeyboardShortcuts,
+} from '@folio/stripes/components';
 
-import { keyboardCommands } from '@folio/stripes-erm-components';
 import css from './index.css';
 
 const AgreementsRoute = lazy(() => import('./routes/AgreementsRoute'));
@@ -81,10 +86,6 @@ class App extends React.Component {
     },
   ];
 
-  checkScope = () => {
-    return document.body.contains(document.activeElement);
-  }
-
   render() {
     const { actAs, match: { path } } = this.props;
 
@@ -97,10 +98,10 @@ class App extends React.Component {
     }
 
     return (
-      <CommandList commands={keyboardCommands}>
+      <CommandList commands={defaultKeyboardShortcuts}>
         <HasCommand
           commands={this.shortcuts}
-          isWithinScope={this.checkScope}
+          isWithinScope={checkScope}
           scope={document.body}
         >
           <div className={css.container}>

--- a/src/routes/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute.js
@@ -6,7 +6,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
-import { checkScope, collapseAllSections, expandAllSections, withAsyncValidation } from '@folio/stripes-erm-components';
+import { withAsyncValidation } from '@folio/stripes-erm-components';
 import withFileHandlers from './components/withFileHandlers';
 import { splitRelatedAgreements } from './utilities/processRelatedAgreements';
 import View from '../components/views/AgreementForm';
@@ -275,9 +275,6 @@ class AgreementCreateRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           onBasketLinesAdded: this.handleBasketLinesAdded,
           onAsyncValidate: this.props.checkAsyncValidation,
           onClose: this.handleClose,

--- a/src/routes/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute.js
@@ -7,7 +7,7 @@ import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
-import { checkScope, collapseAllSections, expandAllSections, withAsyncValidation } from '@folio/stripes-erm-components';
+import { withAsyncValidation } from '@folio/stripes-erm-components';
 import withFileHandlers from './components/withFileHandlers';
 import { joinRelatedAgreements, splitRelatedAgreements } from './utilities/processRelatedAgreements';
 import View from '../components/views/AgreementForm';
@@ -423,9 +423,6 @@ class AgreementEditRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           onBasketLinesAdded: this.handleBasketLinesAdded,
           onAsyncValidate: this.props.checkAsyncValidation,
           onClose: this.handleClose,

--- a/src/routes/AgreementLineCreateRoute.js
+++ b/src/routes/AgreementLineCreateRoute.js
@@ -4,7 +4,7 @@ import compose from 'compose-function';
 import { isEmpty } from 'lodash';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { checkScope, collapseAllSections, expandAllSections, isPackage } from '@folio/stripes-erm-components';
+import { isPackage } from '@folio/stripes-erm-components';
 import View from '../components/views/AgreementLineForm';
 import { urls, withSuppressFromDiscovery } from '../components/utilities';
 
@@ -141,9 +141,6 @@ class AgreementLineCreateRoute extends React.Component {
         }}
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           isSuppressFromDiscoveryEnabled,
           onClose: this.handleClose,
         }}

--- a/src/routes/AgreementLineEditRoute.js
+++ b/src/routes/AgreementLineEditRoute.js
@@ -5,7 +5,6 @@ import { isEmpty } from 'lodash';
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 import View from '../components/views/AgreementLineForm';
 import { urls, withSuppressFromDiscovery } from '../components/utilities';
 
@@ -179,9 +178,6 @@ class AgreementLineEditRoute extends React.Component {
         }}
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           isSuppressFromDiscoveryEnabled,
           onClose: this.handleClose,
         }}

--- a/src/routes/AgreementLineViewRoute.js
+++ b/src/routes/AgreementLineViewRoute.js
@@ -5,7 +5,7 @@ import compose from 'compose-function';
 
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
-import { checkScope, collapseAllSections, expandAllSections, Tags } from '@folio/stripes-erm-components';
+import { Tags } from '@folio/stripes-erm-components';
 
 import View from '../components/views/AgreementLine';
 import { urls, withSuppressFromDiscovery } from '../components/utilities';
@@ -179,9 +179,6 @@ class AgreementLineViewRoute extends React.Component {
         }}
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           isSuppressFromDiscoveryEnabled,
           onClose: this.handleClose,
           onDelete: this.handleDelete,

--- a/src/routes/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute.js
@@ -6,7 +6,7 @@ import { injectIntl } from 'react-intl';
 
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
-import { checkScope, collapseAllSections, expandAllSections, preventResourceRefresh, Tags } from '@folio/stripes-erm-components';
+import { preventResourceRefresh, Tags } from '@folio/stripes-erm-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import withFileHandlers from './components/withFileHandlers';
@@ -491,9 +491,6 @@ class AgreementViewRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           onClone: this.handleClone,
           onClose: this.handleClose,
           onDelete: this.handleDelete,

--- a/src/routes/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute.js
@@ -4,7 +4,7 @@ import { get } from 'lodash';
 
 import { stripesConnect } from '@folio/stripes/core';
 import { StripesConnectedSource } from '@folio/stripes/smart-components';
-import { checkScope, generateQueryParams, preventResourceRefresh } from '@folio/stripes-erm-components';
+import { generateQueryParams, preventResourceRefresh } from '@folio/stripes-erm-components';
 
 import View from '../components/views/Agreements';
 import NoPermissions from '../components/NoPermissions';
@@ -179,7 +179,6 @@ class AgreementsRoute extends React.Component {
           supplementaryProperties: resources?.supplementaryProperties?.records ?? [],
           tagsValues: get(resources, 'tagsValues.records', []),
         }}
-        handlers={{ checkScope }}
         history={this.props.history}
         onNeedMoreData={this.handleNeedMoreData}
         queryGetter={this.queryGetter}

--- a/src/routes/EResourceEditRoute.js
+++ b/src/routes/EResourceEditRoute.js
@@ -6,7 +6,6 @@ import compose from 'compose-function';
 import { stripesConnect } from '@folio/stripes/core';
 import { LoadingView } from '@folio/stripes/components';
 
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 import PCIForm from '../components/views/PCIForm';
 import TitleForm from '../components/views/TitleForm';
 import NoPermissions from '../components/NoPermissions';
@@ -130,9 +129,6 @@ class EResourceEditRoute extends React.Component {
         eresource={eresource}
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           isSuppressFromDiscoveryEnabled,
           onClose: this.handleClose,
         }}

--- a/src/routes/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute.js
@@ -5,7 +5,7 @@ import compose from 'compose-function';
 
 import { stripesConnect } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
-import { checkScope, collapseAllSections, expandAllSections, Tags } from '@folio/stripes-erm-components';
+import { Tags } from '@folio/stripes-erm-components';
 
 import View from '../components/views/EResource';
 import { parseMclPageSize, urls, withSuppressFromDiscovery } from '../components/utilities';
@@ -299,9 +299,6 @@ class EResourceViewRoute extends React.Component {
         }}
         handlers={{
           ...handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           isSuppressFromDiscoveryEnabled,
           onFilterPackageContents: this.handleFilterPackageContents,
           onNeedMoreEntitlements: this.handleNeedMoreEntitlements,

--- a/src/routes/UrlCustomizerCreateRoute.js
+++ b/src/routes/UrlCustomizerCreateRoute.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
-import { checkScope, collapseAllSections, expandAllSections } from '@folio/stripes-erm-components';
 import View from '../components/views/UrlCustomizerForm';
 import { urls } from '../components/utilities';
 
@@ -68,9 +67,6 @@ class UrlCustomizerCreateRoute extends React.Component {
       <View
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           onClose: this.handleClose,
         }}
         onSubmit={this.handleSubmit}

--- a/src/routes/UrlCustomizerViewRoute.js
+++ b/src/routes/UrlCustomizerViewRoute.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
-import { checkScope, collapseAllSections, expandAllSections, preventResourceRefresh } from '@folio/stripes-erm-components';
+import { preventResourceRefresh } from '@folio/stripes-erm-components';
 
 import View from '../components/views/UrlCustomizer';
 import { urls } from '../components/utilities';
@@ -102,9 +102,6 @@ class UrlCustomizerViewRoute extends React.Component {
         }}
         handlers={{
           ...this.props.handlers,
-          checkScope,
-          collapseAllSections,
-          expandAllSections,
           onClose: this.handleClose,
           onDelete: this.handleDelete,
           onEdit: this.handleEdit,


### PR DESCRIPTION
- use handleSaveKeyCommand function from stripes-erm-components
- import keyboard functions from stripes-components
- add expand and collapse accordion shortcuts to Platform view
- fix lint error in NoPermissions.test.js