### PR TITLE
DO NOT MERGE UIU-2087: Note Edit Page - doesn't return to record page after click on 'Save&Close'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-agreements
 
 ## 6.1.0 In progress
+* Fix Note Edit Page - doesn't return to record page after click on 'Save&Close'. UIU-2087
 
 ##  6.0.0 2021-03-18
 * Purchase Order Line details not retrieved from /orders/order-lines for Entitlement. ERM-1606

--- a/src/routes/NoteEditRoute.js
+++ b/src/routes/NoteEditRoute.js
@@ -6,7 +6,6 @@ import { NoteEditPage } from '@folio/stripes/smart-components';
 
 import {
   formatNoteReferrerEntityData,
-  urls,
 } from '../components/utilities';
 
 import {
@@ -25,24 +24,19 @@ export default class NoteEditRoute extends Component {
     }).isRequired,
   };
 
-  goToNoteView = () => {
-    const { history, location, match } = this.props;
-
-    history.replace({
-      pathname: urls.noteView(match.params.id),
-      state: location.state,
-    });
-  }
-
   render() {
-    const { location, match } = this.props;
+    const {
+      location,
+      match,
+      history,
+    } = this.props;
 
     return (
       <NoteEditPage
         domain="agreements"
         entityTypePluralizedTranslationKeys={entityTypePluralizedTranslationKeys}
         entityTypeTranslationKeys={entityTypeTranslationKeys}
-        navigateBack={this.goToNoteView}
+        navigateBack={history.goBack}
         noteId={match.params.id}
         paneHeaderAppIcon="agreement"
         referredEntityData={formatNoteReferrerEntityData(location.state)}


### PR DESCRIPTION
## Description
Fix redirect after editing a Note - have to redirect to previous page

## Issues
[UIU-2087](https://issues.folio.org/browse/UIU-2087)