### PR TITLE
Add a surface for Stripes handler modules to present extensions

### DIFF
--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -20,7 +20,7 @@ import {
   collapseAllSections,
   expandAllSections
 } from '@folio/stripes/components';
-import { AppIcon, TitleManager, withStripes } from '@folio/stripes/core';
+import { AppIcon, TitleManager, withStripes, HandlerManager } from '@folio/stripes/core';
 import { NotesSmartAccordion } from '@folio/stripes/smart-components';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import DuplicateAgreementModal from '../DuplicateAgreementModal';
@@ -307,6 +307,7 @@ class Agreement extends React.Component {
                   { data.agreement?.supplementaryDocs?.length > 0 && <SupplementaryDocs {...this.getSectionProps('supplementaryDocs')} /> }
                   { data.agreement?.usageDataProviders?.length > 0 && <UsageData {...this.getSectionProps('usageData')} /> }
                   { data.agreement?.relatedAgreements?.length > 0 && <RelatedAgreements {...this.getSectionProps('relatedAgreements')} /> }
+                  <HandlerManager stripes={this.props.stripes} event="ui-agreements-extension" />
                   <NotesSmartAccordion
                     {...this.getSectionProps('notes')}
                     domainName="agreements"

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -307,7 +307,7 @@ class Agreement extends React.Component {
                   { data.agreement?.supplementaryDocs?.length > 0 && <SupplementaryDocs {...this.getSectionProps('supplementaryDocs')} /> }
                   { data.agreement?.usageDataProviders?.length > 0 && <UsageData {...this.getSectionProps('usageData')} /> }
                   { data.agreement?.relatedAgreements?.length > 0 && <RelatedAgreements {...this.getSectionProps('relatedAgreements')} /> }
-                  <HandlerManager stripes={this.props.stripes} event="ui-agreements-extension" />
+                  <HandlerManager event="ui-agreements-extension" stripes={this.props.stripes} />
                   <NotesSmartAccordion
                     {...this.getSectionProps('notes')}
                     domainName="agreements"


### PR DESCRIPTION
Unlike plugins, for which the "best" plugin of the requested type is selected, _all_ handlers of the relevant type are included. This approach uses the `<HandlerManager>` facility provided by stripes-core.