### PR TITLE
Pass data into handler

### DIFF
--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -317,7 +317,7 @@ class Agreement extends React.Component {
                   { data.agreement?.supplementaryDocs?.length > 0 && <SupplementaryDocs {...this.getSectionProps('supplementaryDocs')} /> }
                   { data.agreement?.usageDataProviders?.length > 0 && <UsageData {...this.getSectionProps('usageData')} /> }
                   { data.agreement?.relatedAgreements?.length > 0 && <RelatedAgreements {...this.getSectionProps('relatedAgreements')} /> }
-                  <HandlerManager event="ui-agreements-extension" stripes={this.props.stripes} />
+                  <HandlerManager event="ui-agreements-extension" stripes={this.props.stripes} data={{ data }} />
                   <NotesSmartAccordion
                     {...this.getSectionProps('notes')}
                     domainName="agreements"

--- a/src/components/views/Agreement.js
+++ b/src/components/views/Agreement.js
@@ -317,7 +317,7 @@ class Agreement extends React.Component {
                   { data.agreement?.supplementaryDocs?.length > 0 && <SupplementaryDocs {...this.getSectionProps('supplementaryDocs')} /> }
                   { data.agreement?.usageDataProviders?.length > 0 && <UsageData {...this.getSectionProps('usageData')} /> }
                   { data.agreement?.relatedAgreements?.length > 0 && <RelatedAgreements {...this.getSectionProps('relatedAgreements')} /> }
-                  <HandlerManager event="ui-agreements-extension" stripes={this.props.stripes} data={{ data }} />
+                  <HandlerManager data={{ data }} event="ui-agreements-extension" stripes={this.props.stripes} />
                   <NotesSmartAccordion
                     {...this.getSectionProps('notes')}
                     domainName="agreements"


### PR DESCRIPTION
The `ui-agreements-extension`-typed plugin ui-plugin-eusage-reports needs to know details of the agreement, which are contained in the `data` object along with other potentially useful information.