### PR TITLE
fix: Empty index.js

### DIFF
--- a/src/components/AgreementSections/UsageData/index.js
+++ b/src/components/AgreementSections/UsageData/index.js
@@ -1,0 +1,1 @@
+export { default } from './UsageData';


### PR DESCRIPTION
Filled an empty index.js file for UsageData that was causing crashes on agreements with usageDataProviders

ERM-1887