### PR TITLE
ERM-1893 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-agreements
 
 ## 8.1.0 In Progress
+
+* Upgrade `@folio/react-intl-safe-html` for `@folio/stripes` `v7` compatibility. ERM-1893.
+
 ## 8.0.0 2021-10-07
 * Refactor mod-configuration permissions to require specific perms instead of all permissions. ERM-1881
 * Fixed bug with error on saving an agreement if a change is made to the visibility (internal) flag of a primary property without populating it. ERM-1771

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
     "@rehooks/local-storage": "2.4.0",
     "compose-function": "^3.0.3",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [ERM-1893](https://issues.folio.org/browse/ERM-1893)