### PR TITLE
Bump up order-lines interface version (hosted env build fix). Refs ERM-1937.

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "licenses": "1.0 2.0 3.0 4.0"
     },
     "optionalOkapiInterfaces": {
-      "order-lines": "1.0 2.0",
+      "order-lines": "2.0 3.0",
       "organizations-storage.interfaces": "2.0",
       "users": "13.0 14.0 15.0"
     },


### PR DESCRIPTION
this commit is just to bump up interface version to fix testing env and deploy recent changes on snapshot.

in scope of order-lines v3.0 `acquisitionMethod` type was changed from hardcoded strings to uuid (dynamic values), so 
ui-agreements app won't be broken with this change, but acquisitionMethod field will display UID instead of readable string

after acquisitionMethod is fixed in this module, module major version should be updated, additionally order-lines v2.0 should be removed from interface dependencies 
