### PR TITLE
fix: Javascript equivalence problem

### DIFF
--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -230,7 +230,7 @@ class AgreementViewRoute extends React.Component {
     const newLines = this.props.resources?.agreementLines?.records ?? [];
     const { mutator } = this.props;
     if (
-      prevProps?.resources?.agreementLines?.records?.length !== this.props?.resources?.agreementLines?.records?.length ||
+      prevLines?.length !== newLines?.length ||
       this.countPoLines(prevLines) !== this.countPoLines(newLines)
       ) {
       await this.fetchOrderLines();
@@ -244,7 +244,7 @@ class AgreementViewRoute extends React.Component {
   }
 
   countPoLines(lines) {
-    return lines.reduce((agg, curr) => agg + curr?.poLines?.length, 0);
+    return lines.reduce((agg, curr) => agg + curr?.poLines?.length || 0, 0);
   }
 
   async fetchOrderLines() {


### PR DESCRIPTION
Infinite loop was being caused by unsafe integer addition. Reminder to myself and anyone else that might be caught out that:

2 + true === 3
2 + false === 2
2 + null === 2
2 + undefined === NaN
Nan === NaN is false

Defaulted any undefined lengths to 0 to avoid this issue.

ERM-1999