### PR TITLE
fix: Agreement Internal Contact fetch

### DIFF
--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -115,9 +115,12 @@ class AgreementViewRoute extends React.Component {
           .map(contact => `id==${contact.user}`)
           .join(' or ');
 
-        return query ? { query } : null;
+        return query ? { query } : '';
       },
-      fetch: props => !!props.stripes.hasInterface('users', '15.0'),
+      fetch: props => (
+        !!props.stripes.hasInterface('users', '15.0') &&
+        props?.resources?.agreement?.records?.[0]?.contacts?.length > 0
+      ),
       permissionsRequired: 'users.collection.get',
       records: 'users',
     },


### PR DESCRIPTION
Ensure initial fetch for users, so that subsequent agreement fetch will then refresh that call (stripes-connect not returning original params would somehow mean that an agrement refresh down the road would not then fetch that resource. This fixes that)
This work includes a tweak to how the `fetch` param is calculated, to avoid an unnecessary initial call to users before the agreement has loaded. This way the resource exists in stripes-connect ready for refreshing, but the call itself is not made.

refs ERM-2063