### PR TITLE
fix: ParseMclPageSize

### DIFF
--- a/src/routes/EResourceViewRoute/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute/EResourceViewRoute.js
@@ -48,7 +48,7 @@ const EResourceViewRoute = ({
   const eresourceAgreementParams = useMemo(() => (
     generateKiwtQueryParams(
       {
-        perPage: parseMclPageSize({ records: settings }, 'entitlements')
+        perPage: parseMclPageSize(settings, 'entitlements')
       },
       {}
     )
@@ -84,7 +84,7 @@ const EResourceViewRoute = ({
   const eresourceEntitlementOptionsParams = useMemo(() => (
     generateKiwtQueryParams(
       {
-        perPage: parseMclPageSize({ records: settings }, 'entitlementOptions')
+        perPage: parseMclPageSize(settings, 'entitlementOptions')
       },
       {}
     )
@@ -119,7 +119,7 @@ const EResourceViewRoute = ({
         sort: [{
           path: 'pti.titleInstance.name'
         }],
-        perPage: parseMclPageSize({ records: settings }, 'packageContents')
+        perPage: parseMclPageSize(settings, 'packageContents')
       },
       {}
     )


### PR DESCRIPTION
Settings for page sizes in eresource view were incorrect, because an incorrect prop shape was being passed to the parsing function.

ERM-2208