### PR TITLE
fix: ISSN not displaying in "E-resources covered by this agreement" list, refs ERM-2206

### DIFF
--- a/src/components/AgreementSections/CoveredEResourcesList/CoveredEResourcesList.js
+++ b/src/components/AgreementSections/CoveredEResourcesList/CoveredEResourcesList.js
@@ -89,7 +89,7 @@ export default class CoveredEResourcesList extends React.Component {
     },
     issn: e => {
       const titleInstance = get(e._object, 'pti.titleInstance', {});
-      return getResourceIdentifier(titleInstance, 'eissn') || getResourceIdentifier(titleInstance, 'pissn');
+      return getResourceIdentifier(titleInstance, 'issn') || getResourceIdentifier(titleInstance, 'eissn') || getResourceIdentifier(titleInstance, 'pissn');
     },
     platform: e => {
       const pti = e?._object?.pti ?? {};


### PR DESCRIPTION
Added an initial check for `issn` ahead of `eissn` and `pissn`, since all new identifiers on TIs will be flattened to `issn`

ERM-2206