### PR TITLE
fix: delete failure callout

### DIFF
--- a/src/settings/components/AgreementsCustomProperties/AgreementsCustomProperties.js
+++ b/src/settings/components/AgreementsCustomProperties/AgreementsCustomProperties.js
@@ -37,7 +37,8 @@ const AgreementsCustomProperties = () => {
     retired: <FormattedMessage id="ui-agreements.settings.supplementaryProperties.retired" />,
     primaryRetired: <FormattedMessage id="ui-agreements.settings.supplementaryProperties.primaryRetired" />,
     ctx: <FormattedMessage id="ui-agreements.settings.supplementaryProperties.category" />,
-    category: <FormattedMessage id="ui-agreements.settings.supplementaryProperties.pickList" />
+    category: <FormattedMessage id="ui-agreements.settings.supplementaryProperties.pickList" />,
+    deleteError: (error, custProp) => (<FormattedMessage id="ui-agreements.settings.supplementaryProperties.deleteError" values={{ label: custProp?.label, error }} />)
   };
 
   const helpPopovers = {

--- a/translations/ui-agreements/en.json
+++ b/translations/ui-agreements/en.json
@@ -595,6 +595,7 @@
   "settings.supplementaryProperties.primaryRetired": "A supplementary property cannot be both primary and deprecated",
   "settings.supplementaryProperties.category": "Category",
   "settings.supplementaryProperties.pickList": "Pick list",
+  "settings.supplementaryProperties.deleteError": "There was an error deleting supplementary property: <strong>{label}</strong>. {error}",
   "settings.values": "values",
   "settings.value": "Value",
   "settings.appSettings": "App settings",


### PR DESCRIPTION
Added translation labelOverride to CustomPropertiesSettings so that we surface deletion failures to the users again, and with a message specific to agreements.

ERM-2204