### PR TITLE
fix: Agreement Tag filter

### DIFF
--- a/src/components/AgreementFilters/AgreementFilters.js
+++ b/src/components/AgreementFilters/AgreementFilters.js
@@ -24,7 +24,6 @@ const FILTERS = [
   'agreementStatus',
   'renewalPriority',
   'isPerpetual',
-  'tags'
 ];
 
 export default function AgreementFilters({ activeFilters, data, filterHandlers }) {


### PR DESCRIPTION
Filtering by tags did not previously work. We were overwriting the important Tag value manipulation via an automated "value" handler which was not meant to include tags

ERM-2223