### PR TITLE
fix: Query Namespacing

### DIFF
--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -74,7 +74,14 @@ const AgreementCreateRoute = ({
   const { mutateAsync: postAgreement } = useMutation(
     [AGREEMENTS_ENDPOINT, 'ui-agreements', 'AgreementCreateRoute', 'createAgreement'],
     (payload) => ky.post(AGREEMENTS_ENDPOINT, { json: payload }).json()
-      .then(({ id, name }) => {
+      .then(({ id, name, linkedLicenses }) => {
+        // Invalidate any linked license's linkedAgreements calls
+        if (linkedLicenses.length) {
+          linkedLicenses.forEach(linkLic => {
+            // I'm still not 100% sure this is the "right" way to go about this.
+            queryClient.invalidateQueries(['ERM', 'License', linkLic?.id, 'LinkedAgreements']); // This is a convention adopted in licenses
+          });
+        }
         /* Invalidate cached queries */
         queryClient.invalidateQueries(AGREEMENTS_ENDPOINT);
 

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -77,7 +77,7 @@ const AgreementEditRoute = ({
   });
 
   const { data: agreement, isLoading: isAgreementLoading } = useQuery(
-    [AGREEMENT_ENDPOINT(agreementId), 'getAgreement'],
+    ['ERM', 'Agreement', agreementId, AGREEMENT_ENDPOINT(agreementId)], // This pattern may need to be expanded to other fetches in Nolana
     () => ky.get(AGREEMENT_ENDPOINT(agreementId)).json()
   );
 
@@ -110,10 +110,18 @@ const AgreementEditRoute = ({
   const { mutateAsync: putAgreement } = useMutation(
     [AGREEMENT_ENDPOINT(agreementId), 'ui-agreements', 'AgreementEditRoute', 'editAgreement'],
     (payload) => ky.put(AGREEMENT_ENDPOINT(agreementId), { json: payload }).json()
-      .then(({ name }) => {
+      .then(({ name, linkedLicenses }) => {
+        // Invalidate any linked license's linkedAgreements calls
+        if (linkedLicenses.length) {
+          linkedLicenses.forEach(linkLic => {
+            // I'm still not 100% sure this is the "right" way to go about this.
+            queryClient.invalidateQueries(['ERM', 'License', linkLic?.id, 'LinkedAgreements']); // This is a convention adopted in licenses
+          });
+        }
+
         /* Invalidate cached queries */
         queryClient.invalidateQueries(AGREEMENTS_ENDPOINT);
-        queryClient.invalidateQueries(AGREEMENT_ENDPOINT(agreementId));
+        queryClient.invalidateQueries(['ERM', 'Agreement', agreementId]);
 
         callout.sendCallout({ message: <FormattedMessage id="ui-agreements.agreements.update.callout" values={{ name }} /> });
         history.push(`${urls.agreementView(agreementId)}${location.search}`);

--- a/src/routes/AgreementLineCreateRoute/AgreementLineCreateRoute.js
+++ b/src/routes/AgreementLineCreateRoute/AgreementLineCreateRoute.js
@@ -11,7 +11,7 @@ import { isPackage } from '@folio/stripes-erm-components';
 
 import View from '../../components/views/AgreementLineForm';
 import { urls } from '../../components/utilities';
-import { AGREEMENT_LINES_ENDPOINT, AGREEMENT_ENDPOINT } from '../../constants/endpoints';
+import { AGREEMENT_LINES_ENDPOINT } from '../../constants/endpoints';
 import { useSuppressFromDiscovery } from '../../hooks';
 
 const AgreementLineCreateRoute = ({
@@ -37,7 +37,7 @@ const AgreementLineCreateRoute = ({
     (payload) => ky.post(AGREEMENT_LINES_ENDPOINT, { json: { ...payload, owner: agreementId } }).json()
       .then(({ id }) => {
         /* Invalidate cached queries */
-        queryClient.invalidateQueries(AGREEMENT_ENDPOINT(agreementId));
+        queryClient.invalidateQueries(['ERM', 'Agreement', agreementId]);
 
         callout.sendCallout({ message: <FormattedMessage id="ui-agreements.line.create.callout" /> });
         history.push(`${urls.agreementLineView(agreementId, id)}${location.search}`);

--- a/src/routes/AgreementLineEditRoute/AgreementLineEditRoute.js
+++ b/src/routes/AgreementLineEditRoute/AgreementLineEditRoute.js
@@ -12,7 +12,7 @@ import { useSuppressFromDiscovery, useChunkedOrderLines } from '../../hooks';
 import { urls } from '../../components/utilities';
 import { endpoints } from '../../constants';
 
-const { AGREEMENT_ENDPOINT, AGREEMENT_LINE_ENDPOINT } = endpoints;
+const { AGREEMENT_LINE_ENDPOINT } = endpoints;
 
 const AgreementLineEditRoute = ({
   handlers,
@@ -40,7 +40,7 @@ const AgreementLineEditRoute = ({
     (payload) => ky.put(AGREEMENT_LINE_ENDPOINT(lineId), { json: payload }).json()
       .then(({ id }) => {
         /* Invalidate cached queries */
-        queryClient.invalidateQueries(AGREEMENT_ENDPOINT(agreementId));
+        queryClient.invalidateQueries(['ERM', 'Agreement', agreementId]);
         queryClient.invalidateQueries(AGREEMENT_LINE_ENDPOINT(lineId));
 
         callout.sendCallout({ message: <FormattedMessage id="ui-agreements.line.update.callout" /> });

--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -57,7 +57,7 @@ const AgreementViewRoute = ({
     },
     isLoading: isAgreementLoading
   } = useQuery(
-    [agreementPath, 'getAgreement'],
+    ['ERM', 'Agreement', agreementId, agreementPath], // This pattern may need to be expanded to other fetches in Nolana
     () => ky.get(agreementPath).json()
   );
 


### PR DESCRIPTION
Changed query namespacing convention for fetching an agreement to that outlined in ERM-2227.
Also invalidate license linkedAgreement calls when an agreement with linked licenses is edited or created.

ERM-2225, ERM-2227