### PR TITLE
fix: Agreement creation/edit null safety

### DIFF
--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -76,7 +76,7 @@ const AgreementCreateRoute = ({
     (payload) => ky.post(AGREEMENTS_ENDPOINT, { json: payload }).json()
       .then(({ id, name, linkedLicenses }) => {
         // Invalidate any linked license's linkedAgreements calls
-        if (linkedLicenses.length) {
+        if (linkedLicenses?.length) {
           linkedLicenses.forEach(linkLic => {
             // I'm still not 100% sure this is the "right" way to go about this.
             queryClient.invalidateQueries(['ERM', 'License', linkLic?.id, 'LinkedAgreements']); // This is a convention adopted in licenses

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -112,7 +112,7 @@ const AgreementEditRoute = ({
     (payload) => ky.put(AGREEMENT_ENDPOINT(agreementId), { json: payload }).json()
       .then(({ name, linkedLicenses }) => {
         // Invalidate any linked license's linkedAgreements calls
-        if (linkedLicenses.length) {
+        if (linkedLicenses?.length) {
           linkedLicenses.forEach(linkLic => {
             // I'm still not 100% sure this is the "right" way to go about this.
             queryClient.invalidateQueries(['ERM', 'License', linkLic?.id, 'LinkedAgreements']); // This is a convention adopted in licenses


### PR DESCRIPTION
Previously agreements without linked licenses would fail to complete after-query calls to invalidate licenses, thanks to a missing null safety, which is now in place

ERM-2229