### PR TITLE
fix: AgreementLine DELETE

### DIFF
--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -101,6 +101,7 @@ const AgreementEditRoute = ({
         { path: 'id' }
       ],
     },
+    nsArray: ['ERM', 'Agreement', agreementId, 'AgreementLines', AGREEMENT_LINES_ENDPOINT, 'AgreementEditRoute'],
     path: AGREEMENT_LINES_ENDPOINT
   });
 

--- a/src/routes/AgreementLineCreateRoute/AgreementLineCreateRoute.js
+++ b/src/routes/AgreementLineCreateRoute/AgreementLineCreateRoute.js
@@ -33,7 +33,7 @@ const AgreementLineCreateRoute = ({
   };
 
   const { mutateAsync: postAgreementLine } = useMutation(
-    [AGREEMENT_LINES_ENDPOINT, 'ui-agreements', 'AgreementLineCreateRoute', 'createAgreementLine'],
+    ['ERM', 'Agreement', agreementId, 'AgreementLines', 'POST', AGREEMENT_LINES_ENDPOINT],
     (payload) => ky.post(AGREEMENT_LINES_ENDPOINT, { json: { ...payload, owner: agreementId } }).json()
       .then(({ id }) => {
         /* Invalidate cached queries */

--- a/src/routes/AgreementLineEditRoute/AgreementLineEditRoute.js
+++ b/src/routes/AgreementLineEditRoute/AgreementLineEditRoute.js
@@ -27,21 +27,22 @@ const AgreementLineEditRoute = ({
   const queryClient = useQueryClient();
   const isSuppressFromDiscoveryEnabled = useSuppressFromDiscovery();
 
+  const agreementLinePath = AGREEMENT_LINE_ENDPOINT(lineId);
+
   const { data: agreementLine = {}, isLoading: isLineLoading } = useQuery(
-    [AGREEMENT_LINE_ENDPOINT(lineId), 'getLine'],
-    () => ky.get(AGREEMENT_LINE_ENDPOINT(lineId)).json()
+    ['ERM', 'AgreementLine', lineId, agreementLinePath],
+    () => ky.get(agreementLinePath).json()
   );
 
   const poLineIdsArray = (agreementLine.poLines ?? []).map(poLine => poLine.poLineId).flat();
   const { orderLines, isLoading: areOrderLinesLoading } = useChunkedOrderLines(poLineIdsArray);
 
   const { mutateAsync: putAgreementLine } = useMutation(
-    [AGREEMENT_LINE_ENDPOINT(lineId), 'ui-agreements', 'AgreementLineEditRoute', 'editAgreementLine'],
-    (payload) => ky.put(AGREEMENT_LINE_ENDPOINT(lineId), { json: payload }).json()
+    ['ERM', 'AgreementLine', lineId, 'PUT', agreementLinePath],
+    (payload) => ky.put(agreementLinePath, { json: payload }).json()
       .then(({ id }) => {
         /* Invalidate cached queries */
         queryClient.invalidateQueries(['ERM', 'Agreement', agreementId]);
-        queryClient.invalidateQueries(AGREEMENT_LINE_ENDPOINT(lineId));
 
         callout.sendCallout({ message: <FormattedMessage id="ui-agreements.line.update.callout" /> });
         history.push(`${urls.agreementLineView(agreementId, id)}${location.search}`);

--- a/src/routes/AgreementLineViewRoute/AgreementLineViewRoute.js
+++ b/src/routes/AgreementLineViewRoute/AgreementLineViewRoute.js
@@ -10,7 +10,7 @@ import View from '../../components/views/AgreementLine';
 import { urls } from '../../components/utilities';
 
 import { useAgreementsHelperApp, useChunkedOrderLines, useSuppressFromDiscovery } from '../../hooks';
-import { AGREEMENT_LINES_ENDPOINT, AGREEMENT_LINE_ENDPOINT } from '../../constants/endpoints';
+import { AGREEMENT_ENDPOINT, AGREEMENT_LINE_ENDPOINT } from '../../constants/endpoints';
 
 const AgreementLineViewRoute = ({
   handlers,
@@ -25,19 +25,21 @@ const AgreementLineViewRoute = ({
   const ky = useOkapiKy();
 
   const agreementLinePath = AGREEMENT_LINE_ENDPOINT(lineId);
+  const agreementPath = AGREEMENT_ENDPOINT(agreementId);
 
   const { data: agreementLine = {}, isLoading: isLineQueryLoading } = useQuery(
-    [AGREEMENT_LINE_ENDPOINT(lineId), 'getLine'],
+    ['ERM', 'AgreementLine', lineId, agreementLinePath],
     () => ky.get(agreementLinePath).json()
   );
 
   const { mutateAsync: deleteAgreementLine } = useMutation(
-    [agreementLinePath, 'ui-agreements', 'AgreementLineViewRoute', 'deleteAgreementLine'],
-    () => ky.put(agreementLinePath, {
+    // As opposed to ['ERM', 'AgreementLine', lineId, 'DELETE', agreementLinePath] if we did this via a DELETE call to entitlements endpoint
+    ['ERM', 'AgreementLine', lineId, 'DELETE', agreementPath],
+    () => ky.put(agreementPath, { json: {
       id: agreementId,
       items: [{ id: lineId, _delete: true }]
-    }).then(() => {
-      queryClient.invalidateQueries(AGREEMENT_LINES_ENDPOINT);
+    } }).then(() => {
+      queryClient.invalidateQueries('ERM', 'Agreement', agreementId); // Invalidate relevant Agreement
       history.push(`${urls.agreementView(agreementId)}${location.search}`);
       callout.sendCallout({ message: <FormattedMessage id="ui-agreements.line.delete.callout" /> });
     }).catch(error => {

--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -101,7 +101,7 @@ const AgreementViewRoute = ({
     results: agreementLines = [],
     total: agreementLineCount = 0
   } = useInfiniteFetch(
-    [AGREEMENT_LINES_ENDPOINT, agreementLineQueryParams, 'ui-agreements', 'AgreementViewRoute', 'getLines'],
+    ['ERM', 'Agreement', agreementId, 'AgreementLines', AGREEMENT_LINES_ENDPOINT, agreementLineQueryParams],
     ({ pageParam = 0 }) => {
       const params = [...agreementLineQueryParams, `offset=${pageParam}`];
       return ky.get(`${AGREEMENT_LINES_ENDPOINT}?${params?.join('&')}`).json();


### PR DESCRIPTION
Deletion from AgreementLineViewRoute was broken, but this should fix that. Also refactored query namespacing to hopefully clean up some of the invalidation logic