### PR TITLE
build: Kint-Components dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@folio/stripes-acq-components": "^3.1.0",
     "@folio/stripes-erm-components": "^6.2.0",
-    "@k-int/stripes-kint-components": "^2.8.0",
+    "@k-int/stripes-kint-components": "^2.8.2",
     "@rehooks/local-storage": "2.4.4",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.4",


### PR DESCRIPTION
Bumped kint-components dependency to 2.8.2 to ensure we get the EBSCO-safe error handling in settings

ERM-2282