### PR TITLE
chore: Tags invalidation comment

### DIFF
--- a/src/components/views/Agreement/Agreement.js
+++ b/src/components/views/Agreement/Agreement.js
@@ -297,6 +297,7 @@ const Agreement = ({
           </TitleManager>
         </Pane>
         <HelperComponent
+          invalidateLinks={data.tagsInvalidateLinks}
           link={data.tagsLink}
           onToggle={handlers.onToggleTags}
         />
@@ -332,7 +333,8 @@ Agreement.propTypes = {
     agreement: PropTypes.object.isRequired,
     eresourcesFilterPath: PropTypes.string,
     searchString: PropTypes.string,
-    tagsLink: PropTypes.string
+    tagsLink: PropTypes.string,
+    tagsInvalidateLinks: PropTypes.arrayOf(PropTypes.array)
   }).isRequired,
   handlers: PropTypes.shape({
     onClone: PropTypes.func.isRequired,

--- a/src/components/views/AgreementLine/AgreementLine.js
+++ b/src/components/views/AgreementLine/AgreementLine.js
@@ -52,6 +52,7 @@ const propTypes = {
         length: PropTypes.number,
       })),
     }).isRequired,
+    tagsInvalidateLinks: PropTypes.arrayOf(PropTypes.array),
     tagsLink: PropTypes.string,
     settings: PropTypes.object,
   }),
@@ -71,7 +72,7 @@ const AgreementLine = ({
     TagButton,
     HelperComponent,
   },
-  data: { line, tagsLink },
+  data: { line, tagsLink, tagsInvalidateLinks },
   handlers,
   isLoading,
 }) => {
@@ -193,6 +194,7 @@ const AgreementLine = ({
           </AccordionStatus>
         </Pane>
         <HelperComponent
+          invalidateLinks={tagsInvalidateLinks}
           link={tagsLink}
           onToggle={handlers.onToggleTags}
         />

--- a/src/routes/AgreementLineViewRoute/AgreementLineViewRoute.js
+++ b/src/routes/AgreementLineViewRoute/AgreementLineViewRoute.js
@@ -91,7 +91,8 @@ const AgreementLineViewRoute = ({
       }}
       data={{
         line: getCompositeLine(),
-        tagsLink: agreementLinePath
+        tagsLink: agreementLinePath,
+        tagsInvalidateLinks: [['ERM', 'AgreementLine', lineId]]
       }}
       handlers={{
         ...handlers,

--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -316,7 +316,8 @@ const AgreementViewRoute = ({
         agreement: getCompositeAgreement(),
         eresourcesFilterPath,
         searchString: location.search,
-        tagsLink: agreementPath
+        tagsLink: agreementPath,
+        tagsInvalidateLinks: [['ERM', 'Agreement', agreementId]],
       }}
       handlers={{
         ...handlers,

--- a/src/routes/EResourceViewRoute/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute/EResourceViewRoute.js
@@ -35,6 +35,7 @@ const EResourceViewRoute = ({
   const eresourcePath = ERESOURCE_ENDPOINT(eresourceId);
 
   const { data: eresource = {}, isLoading: isEresourceLoading } = useQuery(
+    // NOTE Used in invalidateLinks for tags below!
     [eresourcePath, 'getEresource'],
     () => ky.get(eresourcePath).json()
   );


### PR DESCRIPTION
Currently the Tags component relies on the invalidation for the resource being the same as its fetch endpoint, added comments to this effect, and invalidateLinks to the Tags component where necessary

ERM-2297