### PR TITLE
fix: useKiwtFieldArray onAddField used incorrectly

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-agreements ./translations/ui-agreements/compiled"
   },
   "devDependencies": {
-    "@babel/core": "7.18.6",
+    "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.12.1",

--- a/src/components/LicensesFieldArray/LicensesFieldArray.js
+++ b/src/components/LicensesFieldArray/LicensesFieldArray.js
@@ -118,7 +118,7 @@ const LicensesFieldArray = ({
       <Button
         data-test-license-fa-add-button
         id="add-license-btn"
-        onClick={onAddField}
+        onClick={() => onAddField()}
       >
         <FormattedMessage id="ui-agreements.license.addLicense" />
       </Button>


### PR DESCRIPTION
We previously had `onClick={onAddField}` instead of `onClick={() => onAddField()}`. The first one is a javascript shortcut for: `onClick={(e) => onAddField(e)}`, and for this function if you pass a prop in it will use that as the starting point for the field, so it was attempting to add a click event to the field, instead of an empty linked license object.

Also made babel core dep ^ instead of static

ERM-2299