### PR TITLE
ERM-2338: Selecting "Agreement line type" boxes in filter should use OR (||) not AND

### DIFF
--- a/src/components/AgreementLineFilters/AgreementLineFilters.js
+++ b/src/components/AgreementLineFilters/AgreementLineFilters.js
@@ -93,7 +93,7 @@ const AgreementLineFilters = ({
      * of a list of values since for historical reasons having no filterKey means that the
      * filters get sent separately instead of joined by ||.
      */
-    const groupFilters = activeFilters[name] || [''];
+    const groupFilters = activeFilters[name] || [];
 
     return (
       <Accordion
@@ -108,12 +108,13 @@ const AgreementLineFilters = ({
           dataOptions={filterState[name] || []}
           name={name}
           onChange={(group) => {
+            const newValue = group.values?.filter(gv => !!gv)?.join('||') ?? '';
             filterHandlers.state({
               ...activeFilters,
-              [group.name]: [group.values?.filter(gv => !!gv)?.join('||') ?? '']
+              [group.name]: (newValue ? [newValue] : [])
             });
           }}
-          selectedValues={groupFilters[0]?.split('||')}
+          selectedValues={groupFilters[0]?.split('||') ?? []}
         />
       </Accordion>
     );

--- a/src/components/AgreementLineFilters/AgreementLineFilters.js
+++ b/src/components/AgreementLineFilters/AgreementLineFilters.js
@@ -87,8 +87,13 @@ const AgreementLineFilters = ({
     }
   }, [agreementFilterName, agreementId, data, filterState, poLineFilterNumber, poLineId]);
 
-  const renderCheckboxFilter = (name, prps) => {
-    const groupFilters = activeFilters[name] || [];
+  const renderLineTypeFilter = () => {
+    const name = 'lineType';
+    /* Do some wrangling to make sure we always have a single || separated string instead
+     * of a list of values since for historical reasons having no filterKey means that the
+     * filters get sent separately instead of joined by ||.
+     */
+    const groupFilters = activeFilters[name] || [''];
 
     return (
       <Accordion
@@ -98,7 +103,6 @@ const AgreementLineFilters = ({
         label={<FormattedMessage id={`ui-agreements.agreementLines.${name}`} />}
         onClearFilter={() => { filterHandlers.clearGroup(name); }}
         separator={false}
-        {...prps}
       >
         <CheckboxFilter
           dataOptions={filterState[name] || []}
@@ -106,10 +110,10 @@ const AgreementLineFilters = ({
           onChange={(group) => {
             filterHandlers.state({
               ...activeFilters,
-              [group.name]: group.values
+              [group.name]: [group.values?.filter(gv => !!gv)?.join('||') ?? '']
             });
           }}
-          selectedValues={groupFilters}
+          selectedValues={groupFilters[0]?.split('||')}
         />
       </Accordion>
     );
@@ -244,7 +248,7 @@ const AgreementLineFilters = ({
   return (
     <AccordionSet>
       {renderAgreementFilter('agreement')}
-      {renderCheckboxFilter('lineType')}
+      {renderLineTypeFilter()}
       {renderDateFilter('activeFrom')}
       {renderDateFilter('activeTo')}
       {renderPOLineFilter('poLine')}


### PR DESCRIPTION
For historical reasons, having no filterKey configured in the generateKiwtQueryParams means that the resulting filter array (such as [type==detached, type isNull] will be sent to the backend as separate filters.

As far as I can tell, we only use this in the custom property filter builder, but it represents a breaking change to a key piece of functionality, so instead of setting up a dodgy hack fix in the generateKiwtQueryParams function itself, or breaking the functionality altogether, this fix wrangles the edge case

Essentially we ensure that ONLY a single filter is EVER sent to generateKiwtQueryParams, similar to what we do with start/end date filters in Agreements

ERM-2338