### PR TITLE
ERM-2382: Unchecking all search field boxes in Agreements carries out search with no fields

### DIFF
--- a/src/routes/AgreementsRoute/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute/AgreementsRoute.js
@@ -65,7 +65,8 @@ const AgreementsRoute = ({
 
   const agreementsQueryParams = useMemo(() => (
     generateKiwtQueryParams({
-      searchKey: qIndex ?? defaultQIndex,
+      /* There were problems with using truthiness ?? on an empty string '' */
+      searchKey: (!!qIndex && qIndex !== '') ? qIndex : defaultQIndex,
       filterKeys: {
         agreementStatus: 'agreementStatus.value',
         contacts: 'contacts.user',


### PR DESCRIPTION
fix: ERM-2382: Unchecking all search field boxes in Agreements carries out search with no fields

QIndex was being adhered to even when it was an empty string: ''. This work adds an explicit check for that case:
`searchKey: qIndex ?? defaultQIndex,` =>
`searchKey: (!!qIndex && qIndex !== '') ? qIndex : defaultQIndex,`

ERM-2382