### PR TITLE
fix: AgreementFilters

### DIFF
--- a/src/components/views/Agreements/Agreements.js
+++ b/src/components/views/Agreements/Agreements.js
@@ -212,12 +212,12 @@ const Agreements = ({
                             </Icon>
                           </Button>
                         </div>
-                        <AgreementFilters
-                          activeFilters={activeFilters.state}
-                          data={data}
-                          filterHandlers={getFilterHandlers()}
-                        />
                       </form>
+                      <AgreementFilters
+                        activeFilters={activeFilters.state}
+                        data={data}
+                        filterHandlers={getFilterHandlers()}
+                      />
                     </Pane>
                   }
                   <Pane


### PR DESCRIPTION
Moved AgreementFilters outside of the <form> rendered for the Search field. This stops the issue where CustomPropertiesFilters was throwing a console error due to a nested <form> component

ERM-2397