### PR TITLE
fix: Make use of new `fetchExternalResources` query param for entitle…

### DIFF
--- a/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
+++ b/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
@@ -49,7 +49,8 @@ const AgreementLinesRoute = ({
         poLine: 'poLines.poLineId',
         tags: 'tags.value',
       },
-      perPage: INITIAL_RESULT_COUNT
+      perPage: INITIAL_RESULT_COUNT,
+      fetchExternalResources: false,
     }, (query ?? {}))
   ), [query, searchKey]);
 


### PR DESCRIPTION
…ments

External entitlement calls have gone back to fetching external resources beingthe default position, with a new queryParam "fetchExternalResources" which can be set to false to quash that.

ERM-2423