### PR TITLE
test: stripes-erm-components translations

### DIFF
--- a/test/helpers/translationsProperties.js
+++ b/test/helpers/translationsProperties.js
@@ -1,11 +1,19 @@
 import { translationsProperties as coreTranslations } from '@folio/stripes-erm-testing';
-import translations from '../../translations/ui-agreements/en';
 
+// Direct import is a bit gross, but so is exposing the translations file...
+// no super great way to do this so this will do for now.
+import ermTranslations from '@folio/stripes-erm-components/translations/stripes-erm-components/en.json';
+
+import translations from '../../translations/ui-agreements/en';
 
 const translationsProperties = [
   {
     prefix: 'ui-agreements',
     translations,
+  },
+  {
+    prefix: 'stripes-erm-components',
+    translations: ermTranslations
   },
   ...coreTranslations
 ];


### PR DESCRIPTION
stripes-erm-testing was previously exporting from stripes-erm-components, which would force a dev dep on stripes-erm-components in ALL implementing modules. This has now been removed, so each implementing module must provide its own translations from stripes-erm-components