### PR TITLE
chore: Tests

### DIFF
--- a/src/components/EResourceIdentifier/EResourceIdentifier.test.js
+++ b/src/components/EResourceIdentifier/EResourceIdentifier.test.js
@@ -1,6 +1,6 @@
 
 
-import { HTML, including } from '@folio/stripes-testing';
+import { HTML, including, List } from '@folio/stripes-testing';
 import { renderWithIntl } from '@folio/stripes-erm-testing';
 import EResourceIdentifier from './EResourceIdentifier';
 
@@ -122,25 +122,21 @@ describe('EResourceIdentifier', () => {
       />
     );
 
-    /* the following is a workaround
-       if PR https://issues.folio.org/browse/STCOM-1040 is fixed
-       write new test(s) with the List and ListItem interactor
-       (https://github.com/folio-org/stripes-testing/blob/master/doc/interactors.md#list)
-    */
-
     test('renders the identifier as a List ', async () => {
-      await HTML({ className: including('list') }).exists();
+      await List('eresourceIdentifier').exists();
     });
   });
 
-  test('renders null for Title with no identifier ', () => {
-    const { container } = renderWithIntl(
+  describe('renders null for Title with no identifier ', () => {
+    renderWithIntl(
       <EResourceIdentifier
         titleInstance={titleInstanceWithoutIdentifier}
         type="isbn"
       />
     );
 
-    expect(container.firstChild).toBeNull();
+    test('does not renders the List ', async () => {
+      await List('eresourceIdentifier').absent();
+    });
   });
 });

--- a/src/components/views/TitleFormInfo/TitleFormInfo.test.js
+++ b/src/components/views/TitleFormInfo/TitleFormInfo.test.js
@@ -54,17 +54,15 @@ describe('TitleFormInfo', () => {
   });
 
   describe('with isSuppressFromDiscovery not true for title', () => {
-    let renderedComponent;
     beforeEach(() => {
-      renderedComponent = renderWithIntl(
+      renderWithIntl(
         <TitleFormInfo isSuppressFromDiscoveryEnabled={isSuppressFromDiscoveryDisabled} />,
         translationsProperties
       );
     });
 
-    test('Does not render the component', () => {
-      const { container } = renderedComponent;
-      expect(container.firstChild).toBeNull();
+    test('does not render the Suppress from discovery Checkbox', async () => {
+      await Checkbox({ id: 'title-suppress-from-discovery' }).absent();
     });
   });
 });


### PR DESCRIPTION
Updated tests to no longer rely on container nulls, since we will break that in future by introducing the overlayContainer