### PR TITLE
style: Responsive panes

### DIFF
--- a/src/components/views/Packages/Packages.js
+++ b/src/components/views/Packages/Packages.js
@@ -30,10 +30,16 @@ import EResourceProvider from '../../EResourceProvider';
 import PackageFilters from '../../PackageFilters';
 
 import { urls } from '../../utilities';
-import { resultCount } from '../../../constants';
+import {
+  KB_TAB_FILTER_PANE,
+  KB_TAB_PANESET,
+  KB_TAB_PANE_ID,
+  resultCount
+} from '../../../constants';
 
 import css from '../Agreements.css';
 import RouteSwitcher from '../../RouteSwitcher';
+
 
 const propTypes = {
   children: PropTypes.object,
@@ -106,11 +112,14 @@ const Packages = ({
             const filterCount = activeFilters.string ? activeFilters.string.split(',').length : 0;
 
             return (
-              <PersistedPaneset appId="@folio/agreements" id="packages-paneset">
+              <PersistedPaneset
+                appId="@folio/agreements"
+                id={KB_TAB_PANESET}
+              >
                 {filterPaneIsVisible &&
                   <Pane
                     defaultWidth="20%"
-                    id="pane-packages-search"
+                    id={KB_TAB_FILTER_PANE}
                     lastMenu={
                       <PaneMenu>
                         <CollapseFilterPaneButton onClick={toggleFilterPane} />
@@ -186,7 +195,7 @@ const Packages = ({
                       :
                       null
                   }
-                  id="pane-packages-list"
+                  id={KB_TAB_PANE_ID}
                   noOverflow
                   padContent={false}
                   paneSub={

--- a/src/components/views/Platforms/Platforms.js
+++ b/src/components/views/Platforms/Platforms.js
@@ -27,7 +27,11 @@ import { useHandleSubmitSearch } from '@folio/stripes-erm-components';
 import { urls } from '../../utilities';
 import css from '../Agreements.css';
 import RouteSwitcher from '../../RouteSwitcher';
-import { KB_TAB_FILTER_PANE, KB_TAB_PANESET, KB_TAB_PANE_ID } from '../../../constants';
+import {
+  KB_TAB_FILTER_PANE,
+  KB_TAB_PANESET,
+  KB_TAB_PANE_ID
+} from '../../../constants';
 
 const propTypes = {
   children: PropTypes.object,

--- a/src/components/views/Titles/Titles.js
+++ b/src/components/views/Titles/Titles.js
@@ -32,7 +32,12 @@ import TitleFilters from '../../TitleFilters';
 import IdentifierReassignmentForm from '../../IdentifierReassignmentForm';
 
 import { urls } from '../../utilities';
-import { resultCount } from '../../../constants';
+import {
+  KB_TAB_FILTER_PANE,
+  KB_TAB_PANESET,
+  KB_TAB_PANE_ID,
+  resultCount
+} from '../../../constants';
 
 import css from '../Agreements.css';
 import RouteSwitcher from '../../RouteSwitcher';
@@ -129,11 +134,14 @@ const Titles = ({
             };
 
             return (
-              <PersistedPaneset appId="@folio/agreements" id="titles-paneset">
+              <PersistedPaneset
+                appId="@folio/agreements"
+                id={KB_TAB_PANESET}
+              >
                 {filterPaneIsVisible &&
                   <Pane
                     defaultWidth="20%"
-                    id="pane-titles-search"
+                    id={KB_TAB_FILTER_PANE}
                     lastMenu={
                       <PaneMenu>
                         <CollapseFilterPaneButton onClick={toggleFilterPane} />
@@ -210,7 +218,7 @@ const Titles = ({
                       :
                       null
                   }
-                  id="pane-titles-list"
+                  id={KB_TAB_PANE_ID}
                   noOverflow
                   padContent={false}
                   paneSub={


### PR DESCRIPTION
Changed pane ids to allow responsive button group to work more seamlessly accross the local kb search tabs