### PR TITLE
ERM-2888 Do not load Agreement lines as part of agreement when viewin...

### DIFF
--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -45,7 +45,7 @@ const AgreementViewRoute = ({
   const agreementPath = AGREEMENT_ENDPOINT(agreementId);
   const agreementEresourcesPath = AGREEMENT_ERESOURCES_ENDPOINT(agreementId, eresourcesFilterPath);
 
-  const { agreement, isAgreementLoading } = useAgreement({ agreementId });
+  const { agreement, isAgreementLoading } = useAgreement({ agreementId, queryParams: ['expandItems=false'] });
 
 
   const interfaces = useInterfaces({
@@ -225,7 +225,7 @@ const AgreementViewRoute = ({
   const handleDelete = () => {
     const compositeAgreement = getCompositeAgreement();
 
-    if (compositeAgreement.items?.length) {
+    if (compositeAgreement.lines?.length) {
       callout.sendCallout({ type: 'error', timeout: 0, message: <FormattedMessage id="ui-agreements.errors.noDeleteHasAgreementLines" /> });
       return;
     }

--- a/src/routes/AgreementsRoute/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute/AgreementsRoute.js
@@ -88,8 +88,7 @@ const AgreementsRoute = ({
       sortKeys: {
         agreementStatus: 'agreementStatus.label',
       },
-      perPage: INITIAL_RESULT_COUNT,
-      // expandItems: false
+      perPage: INITIAL_RESULT_COUNT
     }, (query ?? {}))
   ), [qIndex, query]);
 

--- a/src/routes/AgreementsRoute/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute/AgreementsRoute.js
@@ -26,14 +26,14 @@ const [
   ORG_ROLE,
   AGREEMENT_CONTENT_TYPE
 ] = [
-    'SubscriptionAgreement.AgreementStatus',
-    'SubscriptionAgreement.ReasonForClosure',
-    'SubscriptionAgreement.RenewalPriority',
-    'Global.Yes_No',
-    'InternalContact.Role',
-    'SubscriptionAgreementOrg.Role',
-    'SubscriptionAgreement.ContentType'
-  ];
+  'SubscriptionAgreement.AgreementStatus',
+  'SubscriptionAgreement.ReasonForClosure',
+  'SubscriptionAgreement.RenewalPriority',
+  'Global.Yes_No',
+  'InternalContact.Role',
+  'SubscriptionAgreementOrg.Role',
+  'SubscriptionAgreement.ContentType'
+];
 
 const AgreementsRoute = ({
   children,
@@ -89,7 +89,7 @@ const AgreementsRoute = ({
         agreementStatus: 'agreementStatus.label',
       },
       perPage: INITIAL_RESULT_COUNT,
-      fetchItems: false
+      // expandItems: false
     }, (query ?? {}))
   ), [qIndex, query]);
 

--- a/src/routes/AgreementsRoute/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute/AgreementsRoute.js
@@ -26,14 +26,14 @@ const [
   ORG_ROLE,
   AGREEMENT_CONTENT_TYPE
 ] = [
-  'SubscriptionAgreement.AgreementStatus',
-  'SubscriptionAgreement.ReasonForClosure',
-  'SubscriptionAgreement.RenewalPriority',
-  'Global.Yes_No',
-  'InternalContact.Role',
-  'SubscriptionAgreementOrg.Role',
-  'SubscriptionAgreement.ContentType'
-];
+    'SubscriptionAgreement.AgreementStatus',
+    'SubscriptionAgreement.ReasonForClosure',
+    'SubscriptionAgreement.RenewalPriority',
+    'Global.Yes_No',
+    'InternalContact.Role',
+    'SubscriptionAgreementOrg.Role',
+    'SubscriptionAgreement.ContentType'
+  ];
 
 const AgreementsRoute = ({
   children,
@@ -88,7 +88,8 @@ const AgreementsRoute = ({
       sortKeys: {
         agreementStatus: 'agreementStatus.label',
       },
-      perPage: INITIAL_RESULT_COUNT
+      perPage: INITIAL_RESULT_COUNT,
+      fetchItems: false
     }, (query ?? {}))
   ), [qIndex, query]);
 


### PR DESCRIPTION
…g the agreement

* add `expandItems=false` to AgreementViewRoute's queryParams
* use `lines` instead of `items` in AgreementViewRoute