### PR TITLE
ERM-2897: Change number of agreement lines loaded in Agreement line search to 25, ERM-2898: Change number of agreements loaded in Agreement search to 25

### DIFF
--- a/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
+++ b/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
@@ -14,7 +14,7 @@ import { useEresourcesEnabled } from '../../hooks';
 import { AGREEMENT_LINES_ENDPOINT } from '../../constants/endpoints';
 
 const {
-  INITIAL_RESULT_COUNT,
+  RESULT_COUNT_INCREMENT_MEDIUM,
 } = resultCount;
 
 const AgreementLinesRoute = ({
@@ -49,7 +49,7 @@ const AgreementLinesRoute = ({
         poLine: 'poLines.poLineId',
         tags: 'tags.value',
       },
-      perPage: INITIAL_RESULT_COUNT,
+      perPage: RESULT_COUNT_INCREMENT_MEDIUM,
       fetchExternalResources: false,
     }, (query ?? {}))
   ), [query, searchKey]);

--- a/src/routes/AgreementsRoute/AgreementsRoute.js
+++ b/src/routes/AgreementsRoute/AgreementsRoute.js
@@ -14,7 +14,7 @@ import { AGREEMENTS_ENDPOINT } from '../../constants/endpoints';
 import { useAgreementsRefdata } from '../../hooks';
 
 const {
-  INITIAL_RESULT_COUNT,
+  RESULT_COUNT_INCREMENT_MEDIUM,
 } = resultCount;
 
 const [
@@ -88,7 +88,7 @@ const AgreementsRoute = ({
       sortKeys: {
         agreementStatus: 'agreementStatus.label',
       },
-      perPage: INITIAL_RESULT_COUNT
+      perPage: RESULT_COUNT_INCREMENT_MEDIUM
     }, (query ?? {}))
   ), [qIndex, query]);
 


### PR DESCRIPTION
chore: Fetch 25 resources

Changed Agreements/Agreement Lines SASQ screens to fetch 25 resources at a time instead of 100

refs ERM-2897, ERM-2898