### PR TITLE
ERM-2917: Fix move identifiers e-resource plugin

### DIFF
--- a/src/components/IdentifierReassignmentForm/DestinationTitleIdentifierField/DestinationTitleIdentifierField.js
+++ b/src/components/IdentifierReassignmentForm/DestinationTitleIdentifierField/DestinationTitleIdentifierField.js
@@ -63,8 +63,8 @@ const DestinationTitleIdentifierField = ({ setTitleName }) => {
         <Pluggable
           dataKey="destinationIdentifierLookup"
           onEresourceSelected={ti => {
-            setDestinationTI(ti._object);
-            change('destinationTIObject', ti?._object);
+            setDestinationTI(ti);
+            change('destinationTIObject', ti);
             change('destinationTitle');
           }}
           renderTrigger={(pluggableRenderProps) => {

--- a/src/components/IdentifierReassignmentForm/SourceTitleIdentifierField/SourceTitleIdentifierField.js
+++ b/src/components/IdentifierReassignmentForm/SourceTitleIdentifierField/SourceTitleIdentifierField.js
@@ -58,8 +58,8 @@ const SourceTitleIdentifierField = ({ setTitleName }) => {
               }
             });
 
-            setSourceTI(ti._object);
-            change('sourceTIObject', ti._object);
+            setSourceTI(ti);
+            change('sourceTIObject', ti);
           }}
           renderTrigger={(pluggableRenderProps) => {
             triggerButton = pluggableRenderProps.buttonRef;


### PR DESCRIPTION
Fixed an issue in which selecting a title for either source or destination title within the move identifiers modal would not have that title be set within the card

[ERM-2917](https://issues.folio.org/browse/ERM-2917)