### PR TITLE
ERM-2421: Agreement lines and entitlements additional fetches

### DIFF
--- a/src/components/views/AgreementForm/AgreementForm.js
+++ b/src/components/views/AgreementForm/AgreementForm.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import { FormattedMessage } from 'react-intl';
@@ -54,31 +54,9 @@ const AgreementForm = ({
   values = {},
 }) => {
   const accordionStatusRef = useRef();
-  const [addedLinesToAdd, setAddedLinesToAdd] = useState(false);
   const { data: custpropContexts = [] } = useAgreementsContexts();
   // Ensure the custprops with no contexts get rendered
   const contexts = ['isNull', ...custpropContexts];
-
-  // The `agreementLinesToAdd` must be added here rather than in the parent route
-  // handler because we don't want them to be part of the initialValues.
-  // After all, they're being _added_, so their presence must dirty the form.
-  useEffect(() => {
-    const formState = form.getState();
-
-    if (
-      data.agreementLinesToAdd?.length &&
-      addedLinesToAdd === false &&
-      form.getRegisteredFields().includes('items')
-    ) {
-      form.change('items', [
-        ...(formState?.initialValues?.items ?? []),
-        ...data.agreementLinesToAdd,
-      ]);
-
-      handlers.onBasketLinesAdded();
-      setAddedLinesToAdd(true);
-    }
-  }, [addedLinesToAdd, data, form, handlers]);
 
   const initialAccordionsState = {
     formInternalContacts: true,

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -74,7 +74,7 @@ const AgreementEditRoute = ({
 
   const { data: agreement, isLoading: isAgreementLoading } = useQuery(
     ['ERM', 'Agreement', agreementId, AGREEMENT_ENDPOINT(agreementId)], // This pattern may need to be expanded to other fetches in Nolana
-    () => ky.get(AGREEMENT_ENDPOINT(agreementId)).json()
+    () => ky.get(AGREEMENT_ENDPOINT(`${agreementId}?expandItems=false`)).json()
   );
 
   // Users

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -8,16 +8,16 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useBatchedFetch, useUsers } from '@folio/stripes-erm-components';
+import { getRefdataValuesByDesc, useUsers } from '@folio/stripes-erm-components';
 
 import { joinRelatedAgreements, splitRelatedAgreements } from '../utilities/processRelatedAgreements';
 import View from '../../components/views/AgreementForm';
 import NoPermissions from '../../components/NoPermissions';
 import { urls } from '../../components/utilities';
 import { endpoints } from '../../constants';
-import { useAddFromBasket, useAgreementsRefdata, useBasket, useChunkedOrderLines } from '../../hooks';
+import { useAgreementsRefdata, useBasket } from '../../hooks';
 
-const { AGREEMENT_ENDPOINT, AGREEMENT_LINES_ENDPOINT } = endpoints;
+const { AGREEMENT_ENDPOINT } = endpoints;
 
 const [
   AGREEMENT_STATUS,
@@ -57,11 +57,6 @@ const AgreementEditRoute = ({
 
   const { basket = [] } = useBasket();
 
-  const {
-    handleBasketLinesAdded,
-    getAgreementLinesToAdd
-  } = useAddFromBasket(basket);
-
   const refdata = useAgreementsRefdata({
     desc: [
       AGREEMENT_STATUS,
@@ -81,30 +76,6 @@ const AgreementEditRoute = ({
     ['ERM', 'Agreement', agreementId, AGREEMENT_ENDPOINT(agreementId)], // This pattern may need to be expanded to other fetches in Nolana
     () => ky.get(AGREEMENT_ENDPOINT(agreementId)).json()
   );
-
-  // AGREEMENT LINES BATCHED FETCH
-  const {
-    results: agreementLines,
-    total: agreementLineCount,
-    isLoading: areLinesLoading
-  } = useBatchedFetch({
-    batchParams: {
-      filters: [
-        {
-          path: 'owner',
-          value: agreementId
-        }
-      ],
-      sort: [
-        { path: 'type' },
-        { path: 'resource.name' },
-        { path: 'reference' },
-        { path: 'id' }
-      ],
-    },
-    nsArray: ['ERM', 'Agreement', agreementId, 'AgreementLines', AGREEMENT_LINES_ENDPOINT, 'AgreementEditRoute'],
-    path: AGREEMENT_LINES_ENDPOINT
-  });
 
   // Users
   const { data: { users = [] } = {} } = useUsers(agreement?.contacts?.filter(c => c.user)?.map(c => c.user));
@@ -133,7 +104,7 @@ const AgreementEditRoute = ({
   const getInitialValues = useCallback(() => {
     let initialValues = {};
 
-    if (agreement.id === agreementId) { // Not sure what this protects against right now
+    if (agreement?.id === agreementId) { // Not sure what this protects against right now
       initialValues = cloneDeep(agreement);
     }
 
@@ -141,7 +112,6 @@ const AgreementEditRoute = ({
       agreementStatus = {},
       contacts = [],
       isPerpetual = {},
-      items = [],
       linkedLicenses = [],
       orgs = [],
       reasonForClosure = {},
@@ -177,40 +147,8 @@ const AgreementEditRoute = ({
 
     joinRelatedAgreements(initialValues);
 
-    // Check agreement lines correspond to this agreement
-    if (!areLinesLoading && items.length && agreementLineCount && (agreementLines[0].owner.id === agreementId)) {
-      initialValues.items = items.map(item => {
-        // We weed out any external entitlements, then map the internal ones to our form shape
-        if (item.resource) return item;
-
-        const line = agreementLines.find(l => l.id === item.id);
-        if (!line) return item;
-
-        return {
-          id: line.id,
-          coverage: line.customCoverage ? line.coverage : undefined,
-          poLines: line.poLines,
-          activeFrom: line.startDate,
-          activeTo: line.endDate,
-          note: line.note
-        };
-      });
-    }
-
     return initialValues;
-  }, [agreement, agreementId, agreementLineCount, agreementLines, areLinesLoading]);
-
-  /*
-   * Calculate poLineIdsArray outside of the useEffect hook,
-   * so we can accurately tell if it changes and avoid infinite loop
-   */
-  const poLineIdsArray = useMemo(() => (
-    agreementLines
-      .filter(line => !!line.poLines?.length)
-      .map(line => (line.poLines.map(poLine => poLine.poLineId))).flat()
-  ), [agreementLines]);
-
-  const { orderLines, isLoading: areOrderLinesLoading } = useChunkedOrderLines(poLineIdsArray);
+  }, [agreement, agreementId]);
 
   const handleClose = () => {
     history.push(`${urls.agreementView(agreementId)}${location.search}`);
@@ -222,15 +160,8 @@ const AgreementEditRoute = ({
     await putAgreement(values);
   };
 
-  const getAgreementLines = () => {
-    return [
-      ...agreementLines,
-      ...getAgreementLinesToAdd(),
-    ];
-  };
-
   const fetchIsPending = () => {
-    return areOrderLinesLoading || isAgreementLoading;
+    return isAgreementLoading;
   };
 
   if (!stripes.hasPerm('ui-agreements.agreements.edit')) return <NoPermissions />;
@@ -239,8 +170,6 @@ const AgreementEditRoute = ({
   return (
     <View
       data={{
-        agreementLines: getAgreementLines(),
-        agreementLinesToAdd: getAgreementLinesToAdd(),
         agreementStatusValues: getRefdataValuesByDesc(refdata, AGREEMENT_STATUS),
         reasonForClosureValues: getRefdataValuesByDesc(refdata, REASON_FOR_CLOSURE),
         amendmentStatusValues: getRefdataValuesByDesc(refdata, AMENDMENT_STATUS),
@@ -249,14 +178,12 @@ const AgreementEditRoute = ({
         documentCategories: getRefdataValuesByDesc(refdata, DOC_ATTACHMENT_TYPE),
         isPerpetualValues: getRefdataValuesByDesc(refdata, GLOBAL_YES_NO),
         licenseLinkStatusValues: getRefdataValuesByDesc(refdata, REMOTE_LICENSE_LINK_STATUS),
-        orderLines,
         orgRoleValues: getRefdataValuesByDesc(refdata, ORG_ROLE),
         renewalPriorityValues: getRefdataValuesByDesc(refdata, RENEWAL_PRIORITY),
         users,
       }}
       handlers={{
         ...handlers,
-        onBasketLinesAdded: handleBasketLinesAdded,
         onClose: handleClose,
       }}
       initialValues={getInitialValues()}

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.test.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.test.js
@@ -20,18 +20,8 @@ import {
 
 import mockRefdata from '../../../test/jest/refdata';
 
-const BasketLineButton = (props) => {
-  return <Button onClick={props.handlers.onBasketLinesAdded}>BasketLineButton</Button>;
-};
-
 const CloseButton = (props) => {
   return <Button onClick={props.handlers.onClose}>CloseButton</Button>;
-};
-
-BasketLineButton.propTypes = {
-  handlers: PropTypes.shape({
-    onBasketLinesAdded: PropTypes.func,
-  }),
 };
 
 CloseButton.propTypes = {
@@ -43,14 +33,8 @@ CloseButton.propTypes = {
 const historyPushMock = jest.fn();
 const onSubmitMock = jest.fn();
 
-const mockBasketLinesAdded = jest.fn();
-
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
-  useAddFromBasket: () => ({
-    getAgreementLinesToAdd: () => [],
-    handleBasketLinesAdded: mockBasketLinesAdded
-  }),
   useAgreementsRefdata: () => mockRefdata,
 }));
 
@@ -58,7 +42,6 @@ jest.mock('../../components/views/AgreementForm', () => {
   return (props) => (
     <div>
       <div>AgreementForm</div>
-      <BasketLineButton {...props} />
       <CloseButton {...props} />
     </div>
   );
@@ -93,11 +76,6 @@ describe('AgreementEditRoute', () => {
     test('renders the agreementForm component', () => {
       const { getByText } = renderComponent;
       expect(getByText('AgreementForm')).toBeInTheDocument();
-    });
-
-    test('calls the BasketLineButton', async () => {
-      await ButtonInteractor('BasketLineButton').click();
-      expect(mockBasketLinesAdded).toHaveBeenCalled();
     });
 
     test('calls the CloseButton', async () => {


### PR DESCRIPTION
Removed additional fetches for agreement lines and entitlements, redundant tests from AgreementEditRoute and props which are no longer used from the AgreementForm view

[ERM-2421](https://issues.folio.org/browse/ERM-2421)