### PR TITLE
ERM-2967: Use useChunkedCQLFetch consistently across ERM

### DIFF
--- a/src/hooks/useChunkedOrderLines.js
+++ b/src/hooks/useChunkedOrderLines.js
@@ -1,80 +1,28 @@
-import { useCallback, useEffect, useState } from 'react';
-
-import { useOkapiKy } from '@folio/stripes/core';
-import { chunk } from 'lodash';
-import { useQueries } from 'react-query';
+import useChunkedCQLFetch from '@folio/stripes-erm-components';
 
 import { ORDER_LINES_ENDPOINT } from '../constants/endpoints';
-
-const useChunkedOrderLines = (poLineIdsArray) => {
-  const ky = useOkapiKy();
-
-  const CONCURRENT_REQUESTS = 5; // Number of requests to make concurrently
-  const STEP_SIZE = 60; // Number of ids to request for per concurrent request
-
-  const chunkedItems = chunk(poLineIdsArray, STEP_SIZE);
-  // chunkedItems will be an array of arrays of size CONCURRENT_REQUESTS * STEP_SIZE
-  // We need to parallelise CONCURRENT_REQUESTS at a time,
-  // and ensure we only fire the next lot once the previous lot are through
-
-  const [isLoading, setIsLoading] = useState(poLineIdsArray?.length > 0);
-
-  // Set up query array, and only enable the first CONCURRENT_REQUESTS requests
-  const getQueryArray = useCallback(() => {
-    const queryArray = [];
-    chunkedItems.forEach((chunkedItem, chunkedItemIndex) => {
-      const query = chunkedItem.map(item => `id==${item}`).join(' or ');
-      queryArray.push({
-        queryKey: [ORDER_LINES_ENDPOINT, chunkedItem],
-        queryFn: () => ky.get(`${ORDER_LINES_ENDPOINT}?limit=1000&query=${query}`).json(),
-        // Only enable once the previous slice has all been fetched
-        enabled: chunkedItemIndex < CONCURRENT_REQUESTS
-      });
-    });
-
-    return queryArray;
-  }, [chunkedItems, ky]);
-
-  const orderLineQueries = useQueries(getQueryArray());
-
-  // Once chunk has finished fetching, fetch next chunk
-  useEffect(() => {
-    const chunkedOLQ = chunk(orderLineQueries, CONCURRENT_REQUESTS);
-    chunkedOLQ.forEach((colq, i) => {
-      // Check that all previous chunk are fetched,
-      // and that all of our current chunk are not fetched and not loading
-      if (
-        i !== 0 &&
-        chunkedOLQ[i - 1]?.every(pcolq => pcolq.isFetched === true) &&
-        colq.every(req => req.isFetched === false) &&
-        colq.every(req => req.isLoading === false)
-      ) {
-        // Trigger fetch for each request in the chunk
-        colq.forEach(req => {
-          req.refetch();
-        });
-      }
-    });
-  }, [orderLineQueries]);
-
-  // Keep easy track of whether this hook is all loaded or not
-  // (This slightly flattens the "isLoading/isFetched" distinction, but it's an ease of use prop)
-  useEffect(() => {
-    const newLoading = poLineIdsArray?.length > 0 && (!orderLineQueries?.length || orderLineQueries?.some(olq => !olq.isFetched));
-
-    if (isLoading !== newLoading) {
-      setIsLoading(newLoading);
-    }
-  }, [isLoading, orderLineQueries, poLineIdsArray?.length]);
-
+// When fetching from a potentially large list of order lines,
+// make sure to chunk the request to avoid hitting limits.
+const useChunkedOrderLines = (poLineIdsArray, queryOptions = {}) => {
+  const {
+    itemQueries: orderLineQueries,
+    isLoading,
+    items: users
+  } = useChunkedCQLFetch({
+    ids: poLineIdsArray,
+    endpoint: ORDER_LINES_ENDPOINT,
+    reduceFunction: (olq) => (
+      olq.reduce((acc, curr) => {
+        return [...acc, ...(curr?.data?.poLines ?? [])];
+      }, [])
+    ),
+    queryOptions
+  });
 
   return {
     orderLineQueries,
     isLoading,
-    // Offer all fetched orderLines in flattened array once ready
-    orderLines: isLoading ? [] : orderLineQueries.reduce((acc, curr) => {
-      return [...acc, ...(curr?.data?.poLines ?? [])];
-    }, [])
+    users
   };
 };
 

--- a/src/hooks/useChunkedOrderLines.js
+++ b/src/hooks/useChunkedOrderLines.js
@@ -1,4 +1,4 @@
-import useChunkedCQLFetch from '@folio/stripes-erm-components';
+import { useChunkedCQLFetch } from '@folio/stripes-erm-components';
 
 import { ORDER_LINES_ENDPOINT } from '../constants/endpoints';
 // When fetching from a potentially large list of order lines,
@@ -7,7 +7,7 @@ const useChunkedOrderLines = (poLineIdsArray, queryOptions = {}) => {
   const {
     itemQueries: orderLineQueries,
     isLoading,
-    items: users
+    items: orderLines
   } = useChunkedCQLFetch({
     ids: poLineIdsArray,
     endpoint: ORDER_LINES_ENDPOINT,
@@ -22,7 +22,7 @@ const useChunkedOrderLines = (poLineIdsArray, queryOptions = {}) => {
   return {
     orderLineQueries,
     isLoading,
-    users
+    orderLines
   };
 };
 


### PR DESCRIPTION
chore: useChunkedOrderLines

Swap useChunkedOrderLines to improved useChunkedCQLFetch implementation

refs ERM-2967