### PR TITLE
ERM-2969: Edit agreement pane crashes when slow (multi-line) query is canceled

### DIFF
--- a/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.js
+++ b/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 
-import { Button, Layout } from '@folio/stripes/components';
+import { Button, Layout, Spinner } from '@folio/stripes/components';
 import { requiredObjectValidator } from '@folio/stripes-erm-components';
 import { useKiwtFieldArray } from '@k-int/stripes-kint-components';
 
@@ -65,14 +65,19 @@ const AgreementLinesFieldArray = ({
   };
   return (
     <div>
-      <div id="agreement-form-lines">
-        {items.length ? renderLines() : renderEmpty()}
-      </div>
-      <IfEResourcesEnabled>
-        <Button id="add-agreement-line-button" onClick={() => onAddField()}>
-          <FormattedMessage id="ui-agreements.agreementLines.addLine" />
-        </Button>
-      </IfEResourcesEnabled>
+      {data.areLinesLoading ?
+        <Spinner /> :
+        <>
+          <div id="agreement-form-lines">
+            {items.length ? renderLines() : renderEmpty()}
+          </div>
+          <IfEResourcesEnabled>
+            <Button id="add-agreement-line-button" onClick={() => onAddField()}>
+              <FormattedMessage id="ui-agreements.agreementLines.addLine" />
+            </Button>
+          </IfEResourcesEnabled>
+        </>
+      }
     </div>
   );
 };
@@ -82,6 +87,7 @@ AgreementLinesFieldArray.propTypes = {
     basket: PropTypes.arrayOf(PropTypes.object),
     agreementLines: PropTypes.arrayOf(PropTypes.object),
     orderLines: PropTypes.arrayOf(PropTypes.object),
+    areLinesLoading: PropTypes.bool
   }),
   fields: PropTypes.shape({
     name: PropTypes.string,

--- a/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.test.js
+++ b/src/components/AgreementLinesFieldArray/AgreementLinesFieldArray.test.js
@@ -212,6 +212,7 @@ describe('AgreementLinesFieldArray', () => {
         >
           <FieldArray
             component={AgreementLinesFieldArray}
+            data={{}}
             name="agreementLines"
           />
         </TestForm>, translationsProperties

--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -121,7 +121,7 @@ const AgreementCreateRoute = ({
   return (
     <View
       data={{
-        agreementLines: getAgreementLinesToAdd(),
+        agreementLines: [],
         agreementLinesToAdd: getAgreementLinesToAdd(),
         agreementStatusValues: getRefdataValuesByDesc(refdata, AGREEMENT_STATUS),
         reasonForClosureValues: getRefdataValuesByDesc(refdata, REASON_FOR_CLOSURE),

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -177,7 +177,7 @@ const AgreementEditRoute = ({
     if (
       !areLinesLoading &&
       agreementLineCount === agreementLines.length &&
-      agreementLines[0].owner.id === agreementId
+      agreementLines[0]?.owner?.id === agreementId
     ) {
       initialValues.items = agreementLines.map(al => {
         if (al.resource) return al;

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -4,11 +4,11 @@ import { FormattedMessage } from 'react-intl';
 
 import { cloneDeep } from 'lodash';
 
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useBatchedFetch, useUsers } from '@folio/stripes-erm-components';
+import { getRefdataValuesByDesc, useAgreement, useBatchedFetch, useUsers } from '@folio/stripes-erm-components';
 
 import { joinRelatedAgreements, splitRelatedAgreements } from '../utilities/processRelatedAgreements';
 import View from '../../components/views/AgreementForm';
@@ -77,17 +77,15 @@ const AgreementEditRoute = ({
     ]
   });
 
-  const { data: agreement, isLoading: isAgreementLoading } = useQuery(
-    ['ERM', 'Agreement', agreementId, AGREEMENT_ENDPOINT(agreementId)], // This pattern may need to be expanded to other fetches in Nolana
-    () => ky.get(AGREEMENT_ENDPOINT(agreementId)).json()
-  );
+  const { agreement, isAgreementLoading } = useAgreement({ agreementId, queryParams: ['expandItems=false'] });
 
   // AGREEMENT LINES BATCHED FETCH
   const {
     results: agreementLines,
     total: agreementLineCount,
-    isLoading: areLinesLoading
+    isFetching: areLinesLoading
   } = useBatchedFetch({
+    batchLimit: Infinity,
     batchParams:  {
       filters: [
         {
@@ -141,7 +139,6 @@ const AgreementEditRoute = ({
       agreementStatus = {},
       contacts = [],
       isPerpetual = {},
-      items = [],
       linkedLicenses = [],
       orgs = [],
       reasonForClosure = {},
@@ -155,7 +152,7 @@ const AgreementEditRoute = ({
     initialValues.reasonForClosure = reasonForClosure.value;
     initialValues.renewalPriority = renewalPriority.value;
     initialValues.contacts = contacts.map(c => ({ ...c, role: c.role.value }));
-    initialValues.orgs = orgs.map(o => ({ ...o, role: o.role && o.role.value }));
+    initialValues.orgs = orgs.map(o => ({ ...o, role: o.role?.value }));
     initialValues.supplementaryDocs = supplementaryDocs.map(o => ({ ...o, atType: o.atType?.value }));
     initialValues.linkedLicenses = linkedLicenses.map(l => ({
       ...l,
@@ -177,22 +174,21 @@ const AgreementEditRoute = ({
 
     joinRelatedAgreements(initialValues);
 
-    // Check agreement lines correspond to this agreement
-    if (!areLinesLoading && items.length && agreementLineCount && (agreementLines[0].owner.id === agreementId)) {
-      initialValues.items = items.map(item => {
-        // We weed out any external entitlements, then map the internal ones to our form shape
-        if (item.resource) return item;
-
-        const line = agreementLines.find(l => l.id === item.id);
-        if (!line) return item;
+    if (
+      !areLinesLoading &&
+      agreementLineCount === agreementLines.length &&
+      agreementLines[0].owner.id === agreementId
+    ) {
+      initialValues.items = agreementLines.map(al => {
+        if (al.resource) return al;
 
         return {
-          id: line.id,
-          coverage: line.customCoverage ? line.coverage : undefined,
-          poLines: line.poLines,
-          activeFrom: line.startDate,
-          activeTo: line.endDate,
-          note: line.note
+          id: al.id,
+          coverage: al.customCoverage ? al.coverage : undefined,
+          poLines: al.poLines,
+          activeFrom: al.startDate,
+          activeTo: al.endDate,
+          note: al.note
         };
       });
     }
@@ -206,7 +202,7 @@ const AgreementEditRoute = ({
    */
   const poLineIdsArray = useMemo(() => (
     agreementLines
-      .filter(line => line.poLines && line.poLines.length)
+      .filter(line => line.poLines?.length)
       .map(line => (line.poLines.map(poLine => poLine.poLineId))).flat()
   ), [agreementLines]);
 
@@ -223,13 +219,6 @@ const AgreementEditRoute = ({
     putAgreement(values);
   };
 
-  const getAgreementLines = () => {
-    return [
-      ...agreementLines,
-      ...getAgreementLinesToAdd(),
-    ];
-  };
-
   const fetchIsPending = () => {
     return areOrderLinesLoading || isAgreementLoading;
   };
@@ -240,9 +229,10 @@ const AgreementEditRoute = ({
   return (
     <View
       data={{
-        agreementLines: getAgreementLines(),
+        agreementLines,
         agreementLinesToAdd: getAgreementLinesToAdd(),
         agreementStatusValues: getRefdataValuesByDesc(refdata, AGREEMENT_STATUS),
+        areLinesLoading,
         reasonForClosureValues: getRefdataValuesByDesc(refdata, REASON_FOR_CLOSURE),
         amendmentStatusValues: getRefdataValuesByDesc(refdata, AMENDMENT_STATUS),
         basket,


### PR DESCRIPTION
Do not expand agreement lines on erm/sas call, and tweak Agreement Line logic in form to handle this change. Instead use batched entitlements call already in place to avoid timeouts.

- Along with this, only attempt to render the lines when all lines are fetched to avoid repeat large render operations

ERM-2969