### PR TITLE
ERM-2973: Replace naive fetch hooks with parallelised ones (and deprecate)

### DIFF
--- a/src/constants/httpStatuses.js
+++ b/src/constants/httpStatuses.js
@@ -1,0 +1,3 @@
+export default {
+  HTTP_422: 422,
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -10,6 +10,7 @@ export { default as resourceTypes } from './resourceTypes';
 export { default as validationEndPoint } from './validationEndPoint';
 export { default as defaultMclPageSize } from './defaultMclPageSize';
 export { default as hiddenAccordions } from './hiddenAccordions';
+export { default as httpStatuses } from './httpStatuses';
 export * as endpoints from './endpoints';
 export { default as defaultQIndex } from './defaultQIndex';
 export * from './panesetConfigs';

--- a/src/routes/AgreementEditRoute/AgreementEditRoute.js
+++ b/src/routes/AgreementEditRoute/AgreementEditRoute.js
@@ -4,11 +4,11 @@ import { FormattedMessage } from 'react-intl';
 
 import { cloneDeep } from 'lodash';
 
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 import { LoadingView } from '@folio/stripes/components';
 import { CalloutContext, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useUsers } from '@folio/stripes-erm-components';
+import { getRefdataValuesByDesc, useAgreement, useChunkedUsers } from '@folio/stripes-erm-components';
 
 import { joinRelatedAgreements, splitRelatedAgreements } from '../utilities/processRelatedAgreements';
 import View from '../../components/views/AgreementForm';
@@ -72,13 +72,10 @@ const AgreementEditRoute = ({
     ]
   });
 
-  const { data: agreement, isLoading: isAgreementLoading } = useQuery(
-    ['ERM', 'Agreement', agreementId, AGREEMENT_ENDPOINT(agreementId)], // This pattern may need to be expanded to other fetches in Nolana
-    () => ky.get(AGREEMENT_ENDPOINT(`${agreementId}?expandItems=false`)).json()
-  );
+  const { agreement, isAgreementLoading } = useAgreement({ agreementId, queryParams: ['expandItems=false'] });
 
   // Users
-  const { data: { users = [] } = {} } = useUsers(agreement?.contacts?.filter(c => c.user)?.map(c => c.user));
+  const { users } = useChunkedUsers(agreement?.contacts?.filter(c => c.user)?.map(c => c.user) ?? []);
 
   const { mutateAsync: putAgreement } = useMutation(
     [AGREEMENT_ENDPOINT(agreementId), 'ui-agreements', 'AgreementEditRoute', 'editAgreement'],

--- a/src/routes/AgreementViewRoute/AgreementViewRoute.js
+++ b/src/routes/AgreementViewRoute/AgreementViewRoute.js
@@ -6,14 +6,14 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { flatten } from 'lodash';
 
-import { useAgreement, useInfiniteFetch, useInterfaces, useUsers, downloadBlob } from '@folio/stripes-erm-components';
+import { useAgreement, useInfiniteFetch, useInterfaces, downloadBlob, useChunkedUsers } from '@folio/stripes-erm-components';
 import { CalloutContext, useOkapiKy } from '@folio/stripes/core';
 
 import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
 
 import View from '../../components/views/Agreement';
 import { parseMclPageSize, urls } from '../../components/utilities';
-import { errorTypes } from '../../constants';
+import { errorTypes, httpStatuses } from '../../constants';
 
 import { joinRelatedAgreements } from '../utilities/processRelatedAgreements';
 
@@ -60,8 +60,7 @@ const AgreementViewRoute = ({
   const settings = useAgreementsSettings();
 
   // Users
-  const { data: { users = [] } = {} } = useUsers(agreement?.contacts?.filter(c => c.user)?.map(c => c.user));
-
+  const { users } = useChunkedUsers(agreement?.contacts?.filter(c => c.user)?.map(c => c.user) ?? []);
   // AGREEMENT LINES INFINITE FETCH
   const agreementLineQueryParams = useMemo(() => (
     generateKiwtQueryParams(
@@ -130,7 +129,7 @@ const AgreementViewRoute = ({
    */
   const poLineIdsArray = useMemo(() => (
     agreementLines
-      .filter(line => line.poLines && line.poLines.length)
+      .filter(line => line.poLines?.length)
       .map(line => (line.poLines.map(poLine => poLine.poLineId))).flat()
   ), [agreementLines]);
 
@@ -141,7 +140,7 @@ const AgreementViewRoute = ({
     (cloneableProperties) => ky.post(`${agreementPath}/clone`, { json: cloneableProperties }).then(response => {
       if (response.ok) {
         return response.text(); // Parse it as text
-      } else if (response.status === 422) { // handle 422 error specifically
+      } else if (response.status === httpStatuses.HTTP_422) { // handle 422 error specifically
         return response.json()
           .then(({ errors }) => {
             throw new Error(intl.formatMessage(

--- a/src/routes/BasketRoute/BasketRoute.js
+++ b/src/routes/BasketRoute/BasketRoute.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 import {
-  useBatchedFetch,
+  useParallelBatchFetch,
 } from '@folio/stripes-erm-components';
 
 import { useBasket } from '../../hooks';
@@ -15,7 +15,7 @@ const BasketRoute = ({ history }) => {
   const { basket, removeFromBasket } = useBasket();
 
   // AGREEMENTS BATCHED FETCH
-  const { results: openAgreements } = useBatchedFetch({
+  const { itemQueries } = useParallelBatchFetch({
     batchParams: {
       filters: [
         {
@@ -25,9 +25,14 @@ const BasketRoute = ({ history }) => {
       ],
       sort: [{ path: 'name' }],
     },
-    nsArray: ['ERM', 'Agreements', AGREEMENTS_ENDPOINT, 'BasketRoute'],
-    path: AGREEMENTS_ENDPOINT,
+    generateQueryKey: ({ offset }) => ['ERM', 'Agreements', AGREEMENTS_ENDPOINT, offset, 'BasketRoute'],
+    endpoint: AGREEMENTS_ENDPOINT,
   });
+
+  // Get items as they come through
+  const openAgreements = itemQueries?.filter(q => !q.isFetching)?.reduce((acc, curr) => {
+    return [...acc, ...(curr?.data?.results ?? [])];
+  }, []);
 
 
   const handleClose = () => {

--- a/src/routes/EResourceViewRoute/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute/EResourceViewRoute.js
@@ -5,17 +5,15 @@ import { useQuery } from 'react-query';
 
 import { useOkapiKy } from '@folio/stripes/core';
 
-import { useInfiniteFetch, useBatchedFetch } from '@folio/stripes-erm-components';
+import { useInfiniteFetch, useParallelBatchFetch } from '@folio/stripes-erm-components';
 import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
 
 import View from '../../components/views/EResource';
 import { parseMclPageSize, urls } from '../../components/utilities';
-import { resultCount, resourceClasses } from '../../constants';
+import { resourceClasses } from '../../constants';
 
 import { useAgreementsHelperApp, useAgreementsSettings, useSuppressFromDiscovery } from '../../hooks';
 import { ERESOURCE_ENDPOINT, ERESOURCE_ENTITLEMENTS_ENDPOINT, ERESOURCE_ENTITLEMENT_OPTIONS_ENDPOINT, ERESOURCE_RELATED_ENTITLEMENTS_ENDPOINT } from '../../constants/endpoints';
-
-const { RECORDS_PER_REQUEST_MEDIUM } = resultCount;
 
 const EResourceViewRoute = ({
   handlers = [],
@@ -71,13 +69,9 @@ const EResourceViewRoute = ({
   );
 
   // RELATED ENTITLEMENTS FOR ERESOURCE BATCH FETCH
-  const {
-    results: relatedEntitlements,
-    isLoading: areRelatedEntitlementsLoading
-  } = useBatchedFetch({
-    batchLimit: entitlementsCount,
-    batchSize: RECORDS_PER_REQUEST_MEDIUM,
-    path: ERESOURCE_RELATED_ENTITLEMENTS_ENDPOINT(eresourceId),
+  const { items: relatedEntitlements, isLoading: areRelatedEntitlementsLoading } = useParallelBatchFetch({
+    generateQueryKey: ({ offset }) => ['ERM', 'Entitlements', ERESOURCE_RELATED_ENTITLEMENTS_ENDPOINT(eresourceId), offset, 'EresourceViewRoute'],
+    endpoint: ERESOURCE_RELATED_ENTITLEMENTS_ENDPOINT(eresourceId),
     queryParams: {
       enabled: (!!eresource?.id && eresource?.class !== resourceClasses?.PACKAGE)
     }


### PR DESCRIPTION
feat: Swap to parallel fetch hooks

Swapped over to use useParallelBatchFetch and useChunkedUsers instead of useBatchedFetch and useUsers

refs ERM-2973, ERM-2976, ERM-2977