### PR TITLE
ERM-3036: unlock @rehooks/local-storage from 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@folio/stripes-acq-components": "^4.0.0",
     "@k-int/stripes-kint-components": "^5.0.0",
-    "@rehooks/local-storage": "2.4.4",
+    "@rehooks/local-storage": "^2.4.4",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.4",
     "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
build: @rehooks/local-storage

Removed lock on @rehooks/local-storage

ERM-3036