### PR TITLE
ERM-3052: In Document filter builder OR displays on screen instead of AND

### DIFF
--- a/src/components/AgreementDocumentFilter/AgreementDocumentFilterRule.js
+++ b/src/components/AgreementDocumentFilter/AgreementDocumentFilterRule.js
@@ -80,7 +80,7 @@ const AgreementDocumentFilterRule = ({
     <Row key={name}>
       <Col xs={2}>
         <Layout className="textCentered">
-          {index === 0 ? null : <FormattedMessage id="ui-agreements.OR" />}
+          {index === 0 ? null : <FormattedMessage id="ui-agreements.AND" />}
         </Layout>
       </Col>
       <Col xs={3}>


### PR DESCRIPTION
Fixed issue in which rule field array would display or instead of and for rules within an idividual filter

[ERM-3052](https://issues.folio.org/browse/ERM-3052)