### PR TITLE
ERM-3052: Related agreements option missing from Agreement content filter

### DIFF
--- a/src/constants/agreementContentOptions.js
+++ b/src/constants/agreementContentOptions.js
@@ -35,6 +35,7 @@ export default [
     value: 'usageDataProviders',
     id: 'ui-agreements.duplicateAgreementModal.usageData',
   },
+  { value: 'relatedAgreements', id: 'ui-agreements.relatedAgreements' },
   {
     value: 'tags',
     id: 'ui-agreements.agreements.tags',


### PR DESCRIPTION
Added related agreements option for the agreement content filter, also added special handling for seperating the related agreement option so that both inward and outward relationships can be queried within the agreement

[ERM-3052](https://issues.folio.org/browse/ERM-3054)