### PR TITLE
ERM-3060: Use "Category" not "Type" in document filter

### DIFF
--- a/src/components/AgreementDocumentFilter/AgreementDocumentFilter.js
+++ b/src/components/AgreementDocumentFilter/AgreementDocumentFilter.js
@@ -93,6 +93,7 @@ const AgreementDocumentFilter = ({ activeFilters, filterHandlers }) => {
 
   return (
     <Accordion
+      closedByDefault
       displayClearButton={!!parsedFilterData?.length}
       header={FilterAccordionHeader}
       id="clickable-agreement-document-filter"

--- a/src/components/AgreementDocumentFilter/AgreementDocumentFilterRule.js
+++ b/src/components/AgreementDocumentFilter/AgreementDocumentFilterRule.js
@@ -55,7 +55,7 @@ const AgreementDocumentFilterRule = ({
       value: 'supplementaryDocs.note',
     },
     {
-      label: intl.formatMessage({ id: 'stripes-erm-components.doc.type' }),
+      label: intl.formatMessage({ id: 'stripes-erm-components.doc.category' }),
       value: 'supplementaryDocs.atType.value',
     },
     {


### PR DESCRIPTION
Replaced "Type" translation with "Category" within attributes data options array

[ERM-3060](https://issues.folio.org/browse/ERM-3060)