### PR TITLE
ERM-3065: Agreement lines are displayed by default on the "Agreement lines" pane.

### DIFF
--- a/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
+++ b/src/routes/AgreementLinesRoute/AgreementLinesRoute.js
@@ -71,7 +71,7 @@ const AgreementLinesRoute = ({
       return ky.get(`${AGREEMENT_LINES_ENDPOINT}?${params?.join('&')}`).json();
     },
     {
-      enabled: !!currentPage
+      enabled: (!!query?.filters || !!query?.query) && !!currentPage
     }
   );
 


### PR DESCRIPTION
fix: Change in enabled logic for agreement lines

While changing AgreementLines to paginated, logic was removed: https://github.com/folio-org/ui-agreements/pull/1257/files#diff-a4104c109644976b86e2b1f79d0df43a92845844a16ff4344e460982f4a71cd9L74 and was subsequently not caught by CodeReview

This PR adds that back in

ERM-3065