### PR TITLE
fix: Filter deparse regex

### DIFF
--- a/src/components/AgreementContentFilter/AgreementContentFilter.js
+++ b/src/components/AgreementContentFilter/AgreementContentFilter.js
@@ -279,8 +279,6 @@ const AgreementContentFilter = ({
         // FIXME this isn't ideal, KIWT should accept spaces in query -- Ask Steve
         agreementContent: [
           deparseKiwtQueryFilters(kiwtQueryFilterShape)
-            .replaceAll(' || ', '||')
-            .replaceAll(' && ', '&&'),
         ],
       });
     }

--- a/src/components/AgreementDocumentFilter/AgreementDocumentFilter.js
+++ b/src/components/AgreementDocumentFilter/AgreementDocumentFilter.js
@@ -85,7 +85,7 @@ const AgreementDocumentFilter = ({ activeFilters, filterHandlers }) => {
       documents: [
         // Currently the deparse function returns a query string containing whitespace which leads to grouping errors
         // This regex removes all whitespace from the querystring
-        deparseKiwtQueryFilters(kiwtQueryShape).replaceAll(/\s/g, ''),
+        deparseKiwtQueryFilters(kiwtQueryShape),
       ],
     });
     setEditingFilters(false);


### PR DESCRIPTION
Removed replaceAll functions from documents and content filters deparseKiwtQueryFilters due to changes made to web-toolkit

ERM-3061