### PR TITLE
ERM-3081: Do not add a space after search operator when doing groupings

### DIFF
--- a/src/components/AgreementContentFilter/AgreementContentFilter.js
+++ b/src/components/AgreementContentFilter/AgreementContentFilter.js
@@ -58,13 +58,13 @@ const AgreementContentFieldArray = ({ handleSubmit }) => {
                       dataOptions={[
                         { value: '', label: '' },
                         {
-                          value: 'isNotEmpty',
+                          value: ' isNotEmpty', // The space is part of the comparator
                           label: intl.formatMessage({
                             id: 'ui-agreements.agreementContent.filter.has',
                           }),
                         },
                         {
-                          value: 'isEmpty',
+                          value: ' isEmpty', // The space is part of the comparator
                           label: intl.formatMessage({
                             id: 'ui-agreements.agreementContent.filter.hasNot',
                           }),
@@ -246,7 +246,7 @@ const AgreementContentFilter = ({
                   path: 'inwardRelationships',
                   comparator: curr.attribute,
                 },
-                curr.attribute === 'isEmpty' ? '&&' : '||',
+                curr.attribute === ' isEmpty' ? '&&' : '||',
                 {
                   path: 'outwardRelationships',
                   comparator: curr.attribute,


### PR DESCRIPTION
fix: Comparator spacing

Fixes made in kint-components means we can no longer bank on lack of spacing for "special" comparators. These _need_ a space as a part of the comparator, and this change reflects that.

ERM-3081