### PR TITLE
ERM-3186 Change default search options for Local KB titles to exclude…

### DIFF
--- a/src/components/views/Titles/Titles.js
+++ b/src/components/views/Titles/Titles.js
@@ -36,6 +36,7 @@ import IdentifierReassignmentForm from '../../IdentifierReassignmentForm';
 
 import { urls } from '../../utilities';
 import {
+  defaultTitlesQIndex as defaultQIndex,
   KB_TAB_FILTER_PANE,
   KB_TAB_PANESET,
   KB_TAB_PANE_ID,
@@ -89,10 +90,16 @@ const Titles = ({
     pageSize: RESULT_COUNT_INCREMENT_MEDIUM
   });
 
+  /*
+   * NOTE: This is not directly defaulting the qIndex,
+   * rather setting up the "default" for inclusion in qIndexSASQProps,
+   * which are passed to SASQ below. Then SASQ will be responsible for setting
+   * initial qIndex values in the url on mount.
+   */
   const {
     qIndexChanged,
     qIndexSASQProps
-  } = useSASQQIndex();
+  } = useSASQQIndex({ defaultQIndex });
 
   const [storedFilterPaneVisibility] = useLocalStorage(filterPaneVisibilityKey, true);
   const [filterPaneIsVisible, setFilterPaneIsVisible] = useState(storedFilterPaneVisibility);

--- a/src/constants/defaultQIndex.js
+++ b/src/constants/defaultQIndex.js
@@ -1,3 +1,3 @@
 // Defined as a constant here because we use it as a fallback for the query AND within the SASQ initial setup
 export const defaultAgreementsQIndex = 'name,alternateNames.name,description';
-export const defaultTitlesQIndex = 'name,identifiers.identifier.value,alternateResourceNames.name,description';
+export const defaultTitlesQIndex = 'name,alternateResourceNames.name,description';

--- a/src/routes/TitlesRoute/TitlesRoute.js
+++ b/src/routes/TitlesRoute/TitlesRoute.js
@@ -65,7 +65,13 @@ const TitlesRoute = ({
   const { query, querySetter, queryGetter } = useKiwtSASQuery();
 
   const { currentPage } = usePrevNextPagination();
-  const { searchKey } = useSASQQIndex({ defaultQIndex });
+
+  /*
+   * Have the default searchKey (When no qIndex is present, meaning no checkboxes are checked) include identifier values
+   * This usage of useSASQQIndex is _not_ setting the qindex in the url,
+   * that is handled in the view via SASQ and the props handed to it.
+   */
+  const { searchKey } = useSASQQIndex({ defaultQIndex: `${defaultQIndex},identifiers.identifier.value` });
 
   const titlesQueryParams = useMemo(() => (
     generateKiwtQueryParams({


### PR DESCRIPTION
… identifiers

* remove identifiers.identifier.value from defaultTitlesQIndex
* add identifiers.identifier.value to the default searchKey (no checkboxes checked, no qIndex)
* set up the 'default' for qIndexSASQProps in Titles view