### PR TITLE
chore: Swap to /static/entitlementOptions

### DIFF
--- a/src/constants/endpoints.js
+++ b/src/constants/endpoints.js
@@ -19,7 +19,7 @@ export const ERESOURCE_ENDPOINT = (eresourceId) => `${ERESOURCES_ENDPOINT}/${ere
 
 export const ERESOURCE_ENTITLEMENTS_ENDPOINT = (eresourceId) => `${ERESOURCE_ENDPOINT(eresourceId)}/entitlements`;
 export const ERESOURCE_RELATED_ENTITLEMENTS_ENDPOINT = (eresourceId) => `${ERESOURCE_ENDPOINT(eresourceId)}/entitlements/related`;
-export const ERESOURCE_ENTITLEMENT_OPTIONS_ENDPOINT = (eresourceId) => `${ERESOURCE_ENDPOINT(eresourceId)}/entitlementOptions`;
+export const ERESOURCE_ENTITLEMENT_OPTIONS_ENDPOINT = (eresourceId) => `${ERESOURCE_ENDPOINT(eresourceId)}/static/entitlementOptions`; // Do a straight swap for static here and use stats as before
 
 export const PCIS_ENDPOINT = 'erm/pci';
 export const PCI_ENDPOINT = (pciId) => `erm/pci/${pciId}`;


### PR DESCRIPTION
Made a tiny tweak to swap the default entitlementOptions fetch out to the newer static endpoint. We don't currently sort or filter on this, so we can do this with no other changes required

refs ERM-3246