### PR TITLE
fix: Extra calls

### DIFF
--- a/src/routes/EResourceViewRoute/EResourceViewRoute.js
+++ b/src/routes/EResourceViewRoute/EResourceViewRoute.js
@@ -125,6 +125,9 @@ const EResourceViewRoute = ({
     () => {
       const params = [...eresourceEntitlementOptionsParams];
       return ky.get(`${entitlementOptionsPath}?${params?.join('&')}`).json();
+    },
+    {
+      enabled: !!entitlementOptionsPage && !!entitlementOptionsPageSize
     }
   );
 


### PR DESCRIPTION
On snapshot we see extra calls to entitlementOptions where `page=undefined`. This does _not_ happen locally for me, which is confusing, but regardless I've added an enabled check to hopefully stop this behaviour

refs ERM-3246 (But is not required for that functionality to work)