### PR TITLE
ERM-3362: Error on viewing ERM basket

### DIFF
--- a/src/components/views/Basket/Basket.js
+++ b/src/components/views/Basket/Basket.js
@@ -200,25 +200,30 @@ const Basket = ({
         <Col md={8} xs={12}>
           <Selection
             dataOptions={openAgreementsState}
-            formatter={({ option }) => (
-              <div
-                data-test-agreement-id={option.id}
-                style={{ textAlign: 'left' }}
-              >
-                <Headline>
-                  {option.name}&nbsp;&#40;{option.agreementStatus.label}&#41;
-                </Headline>
-                {/* eslint-disable-line */}
-                <div>
-                  <strong>
-                    <FormattedMessage id="ui-agreements.agreements.startDate" />
-                    :{' '}
-                  </strong>
-                  <FormattedUTCDate value={option.startDate} />{' '}
+            formatter={({ option }) => {
+              if (!option) {
+                return null;
+              }
+              return (
+                <div
+                  data-test-agreement-id={option.id}
+                  style={{ textAlign: 'left' }}
+                >
+                  <Headline>
+                    {option.name}&nbsp;&#40;{option.agreementStatus.label}&#41;
+                  </Headline>
                   {/* eslint-disable-line */}
+                  <div>
+                    <strong>
+                      <FormattedMessage id="ui-agreements.agreements.startDate" />
+                      :{' '}
+                    </strong>
+                    <FormattedUTCDate value={option.startDate} />{' '}
+                    {/* eslint-disable-line */}
+                  </div>
                 </div>
-              </div>
-            )}
+              );
+            }}
             id="select-agreement-for-basket"
             onChange={(id) => {
               setSelectedAgreementId(id);


### PR DESCRIPTION
fix: Fixes to accommodate stripes changes

Stripes changed to use `formatter` prop in Selection for rendering display as well as the options. This means that a `null` option is now a legitimate use case, which we had not protected for. Added in null safety here, and this also means that the display on selection is equivalent to the options render, which might not be desired but at least this works.

ERM-3362