### PR TITLE
build: Removed nwsapi resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,8 +344,5 @@
         "title": "Print title"
       }
     ]
-  },
-  "resolutions": {
-    "nwsapi" : "2.2.13"
   }
 }


### PR DESCRIPTION
Removed previously required nwsapi resolution pinning version to 2.2.13, issues caused have been resolved as of 2.2.16 release