### PR TITLE
ERM-3608: Stripes v10 dependencies update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/agreements",
-  "version": "11.2.0",
+  "version": "12.0.0",
   "description": "ERM agreement functionality for Stripes",
   "main": "src/index.js",
   "publishConfig": {
@@ -19,14 +19,14 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.0",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
     "@folio/stripes-acq-components": "^6.0.0",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "@folio/stripes-erm-testing": "^3.0.0",
-    "@formatjs/cli": "^6.1.3",
+    "@formatjs/cli": "^6.6.0",
     "classnames": ">=2.2.6",
     "core-js": "^3.6.1",
     "eslint": "^7.32.0",
@@ -34,7 +34,7 @@
     "prop-types-extra": ">=1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.6.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
@@ -44,7 +44,7 @@
     "rxjs": "^6.6.3"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^5.8.3",
+    "@k-int/stripes-kint-components": "^5.11.0",
     "@rehooks/local-storage": "^2.4.4",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.4",
@@ -59,12 +59,12 @@
     "zustand": "^4.1.5"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.0",
+    "@folio/stripes": "^10.0.0",
     "@folio/stripes-acq-components": "^6.0.0",
-    "@folio/stripes-erm-components": "^9.2.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "stripes": {


### PR DESCRIPTION
BREAKING Updated all stripes-* dependencies for the stripes v10 upgrade along with react-intl and formatjs/cli

Bumped version to 12.0.0

ERM-3608