### PR TITLE
ERM-3756 Zero character '0' displaying in package view screen when there is no 'Extended package information' accordion

### DIFF
--- a/src/components/views/Package/Package.js
+++ b/src/components/views/Package/Package.js
@@ -54,7 +54,6 @@ const Package = ({ data, handlers }) => {
   ];
 
   const { eresource: { alternateResourceNames, description, identifiers, packageDescriptionUrls } } = data;
-
   return (
     <HasCommand
       commands={shortcuts}
@@ -70,7 +69,7 @@ const Package = ({ data, handlers }) => {
             </Col>
           </Row>
           <AccordionSet initialStatus={initialAccordionsState}>
-            {(description || alternateResourceNames?.length || packageDescriptionUrls?.length || identifiers?.length) &&
+            {(!!description || !!alternateResourceNames?.length || !!packageDescriptionUrls?.length || !!identifiers?.length) &&
               <ExtendedPackageInformation {...getSectionProps('extendedPackageInformation')} />
             }
             <Agreements


### PR DESCRIPTION
* use boolean coercion to avoid rendering 0 in UI