### PR TITLE
refactor: useHasLicensesInterface -- ERM-3814

### DIFF
--- a/src/components/views/Agreement/Agreement.js
+++ b/src/components/views/Agreement/Agreement.js
@@ -45,15 +45,17 @@ import {
   UsageData,
 } from '../../AgreementSections';
 
-import { useAgreementsContexts, useChunkedOrderLines } from '../../../hooks';
+import {
+  useAgreementsContexts,
+  useChunkedOrderLines,
+  useHasLicensesInterface
+} from '../../../hooks';
 
 import { urls } from '../../utilities';
 import {
   AGREEMENT_ENTITY_TYPE,
   CUSTPROP_ENDPOINT,
   LICENSE_CUSTPROP_ENDPOINT,
-  LICENSES_INTERFACE,
-  LICENSES_INTERFACE_VERSION,
   statuses
 } from '../../../constants';
 
@@ -102,8 +104,7 @@ const Agreement = ({
 
   const stripes = useStripes();
 
-  // Check if licenses interface is present
-  const hasLicensesInterface = stripes.hasInterface(LICENSES_INTERFACE, LICENSES_INTERFACE_VERSION);
+  const { hasLicensesInterface } = useHasLicensesInterface();
 
   const { data: custpropContexts = [] } = useAgreementsContexts();
   // Ensure the custprops with no contexts get rendered

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -9,3 +9,4 @@ export { default as useEresourcesEnabled } from './useEresourcesEnabled';
 export { default as useBasket } from './useBasket';
 export { default as useBasketStore } from './useBasketStore';
 export * from './resourceHooks';
+export { default as useHasLicensesInterface } from './useHasLicensesInterface';

--- a/src/hooks/useHasLicensesInterface.js
+++ b/src/hooks/useHasLicensesInterface.js
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+
+import { useStripes } from '@folio/stripes/core';
+import { LICENSES_INTERFACE, LICENSES_INTERFACE_VERSION } from '../constants';
+
+// Allow overriding of interfaceVersion just in case
+const useHasLicensesInterface = ({ interfaceVersion } = {}) => {
+  const stripes = useStripes();
+
+  const licensesInterface = useMemo(() => {
+    return stripes.hasInterface(LICENSES_INTERFACE, interfaceVersion ?? LICENSES_INTERFACE_VERSION);
+  }, [interfaceVersion, stripes]);
+
+  // hasInterface returns 0 if interface not present *shrug*
+  const hasLicensesInterface = useMemo(() => licensesInterface !== 0, [licensesInterface]);
+
+  return ({
+    licensesInterface,
+    hasLicensesInterface
+  });
+};
+
+export default useHasLicensesInterface;


### PR DESCRIPTION
Added special hook for checking whether the licenses interface is present or not, including a direct boolean return (Pretty overkill tbh)

refs ERM-3814