### PR TITLE
ERM-4014: Change default `headingLevel` in meta section header to `3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-agreements
 
 ## 12.2.0 IN PROGRESS
+  * ERM-4014: Change default `headingLevel` in meta section header to `3`
 
 ## 12.1.0 2026-04-17
   * ERM-3975: Agreements|Local KB Package view: List item li does not have a ul parent element

--- a/src/RemoteKB/components/RemoteKbResourceView/RemoteKbResourceView.js
+++ b/src/RemoteKB/components/RemoteKbResourceView/RemoteKbResourceView.js
@@ -34,6 +34,7 @@ import {
   stableKeyFrom,
 } from '../../utilities';
 
+import { DEFAULT_META_SECTION_HEADING_LEVEL } from '../../../constants';
 import getResultsDisplayConfig from '../../utilities/getResultsDisplayConfig';
 
 const PANE_DEFAULT_WIDTH = '50%';
@@ -152,6 +153,7 @@ const RemoteKbResourceView = ({
           <MetaSection
             contentId="remoteKbResourceMetaContent"
             createdDate={renderValue(value.createdDate)}
+            headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
             hideSource
             lastUpdatedDate={renderValue(value.lastUpdatedDate)}
           />

--- a/src/components/AgreementLineSections/Info/Info.js
+++ b/src/components/AgreementLineSections/Info/Info.js
@@ -22,7 +22,7 @@ import TitleCard from '../../TitleCard';
 import TitleCardExternal from '../../TitleCardExternal';
 import { useLocalGokbPkg } from '../../../hooks';
 import { isDetached, isExternal, urls } from '../../utilities';
-import { GOKB_RESOURCE_AUTHORITY } from '../../../constants';
+import { DEFAULT_META_SECTION_HEADING_LEVEL, GOKB_RESOURCE_AUTHORITY } from '../../../constants';
 
 const propTypes = {
   isSuppressFromDiscoveryEnabled: PropTypes.func.isRequired,
@@ -176,6 +176,7 @@ const Info = ({ isSuppressFromDiscoveryEnabled, line, resource: incomingResource
       <MetaSection
         contentId="agreementLineInfoRecordMetaContent"
         createdDate={line.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="agreementLineInfoRecordMeta"
         lastUpdatedDate={line.lastUpdated}

--- a/src/components/AgreementSections/Info/Info.js
+++ b/src/components/AgreementSections/Info/Info.js
@@ -11,7 +11,7 @@ import {
   Row,
 } from '@folio/stripes/components';
 
-import { statuses } from '../../../constants';
+import { DEFAULT_META_SECTION_HEADING_LEVEL, statuses } from '../../../constants';
 import InfoPeriods from '../InfoPeriods';
 
 const Info = ({ agreement }) => {
@@ -39,6 +39,7 @@ const Info = ({ agreement }) => {
       <MetaSection
         contentId="agreementInfoRecordMetaContent"
         createdDate={agreement.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="agreementInfoRecordMeta"
         lastUpdatedDate={agreement.lastUpdated}

--- a/src/components/EResourceSections/PCIInfo/PCIInfo.js
+++ b/src/components/EResourceSections/PCIInfo/PCIInfo.js
@@ -14,6 +14,7 @@ import {
   MultiColumnList,
 } from '@folio/stripes/components';
 
+import { DEFAULT_META_SECTION_HEADING_LEVEL } from '../../../constants';
 import AddToBasketButton from '../../AddToBasketButton';
 import { buildPCIEntitlementOption } from '../../utilities';
 
@@ -110,6 +111,7 @@ const PCIInfo = ({ pci }) => {
       <MetaSection
         contentId="pciInfoRecordMetaContent"
         createdDate={pci.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="pciInfoRecordMeta"
         lastUpdatedDate={pci.lastUpdated}

--- a/src/components/EResourceSections/PackageInfo/PackageInfo.js
+++ b/src/components/EResourceSections/PackageInfo/PackageInfo.js
@@ -17,6 +17,7 @@ import AddToBasketButton from '../../AddToBasketButton';
 import PackageSyncronisingValue from '../PackageSyncronisingValue';
 import css from '../../styles.css';
 import { buildPackageEntitlementOption } from '../../utilities';
+import { DEFAULT_META_SECTION_HEADING_LEVEL } from '../../../constants';
 
 const PackageInfo = ({
   data: {
@@ -51,6 +52,7 @@ const PackageInfo = ({
       <MetaSection
         contentId="packageInfoRecordMetaContent"
         createdDate={eresource.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="packageInfoRecordMeta"
         lastUpdatedDate={eresource.lastUpdated}

--- a/src/components/views/Title/Title.js
+++ b/src/components/views/Title/Title.js
@@ -26,7 +26,7 @@ import {
 import TitleCardInfo from '../../TitleCard/TitleCardInfo';
 
 import { urls } from '../../utilities';
-import { ERESOURCE_ENTITY_TYPE } from '../../../constants';
+import { DEFAULT_META_SECTION_HEADING_LEVEL, ERESOURCE_ENTITY_TYPE } from '../../../constants';
 
 export default class Title extends React.Component {
   static propTypes = {
@@ -71,6 +71,7 @@ export default class Title extends React.Component {
       <MetaSection
         contentId="titleRecordMetaContent"
         createdDate={eresource.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="titleRecordMeta"
         lastUpdatedDate={eresource.lastUpdated}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -25,3 +25,4 @@ export * from './paginationIds';
 
 export * from './queryKeys';
 export * from './basket';
+export * from './metasection';

--- a/src/constants/metasection.js
+++ b/src/constants/metasection.js
@@ -1,0 +1,1 @@
+export const DEFAULT_META_SECTION_HEADING_LEVEL = 3;


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/ERM-4014

> In Agreements, Licenses, Serials Management, OA, we do not normally have a heading between our view pane header and our metadata section. This leads to a jump in header from H2 to H4 causing accessibility issues. This ticket is to change the default heading level for the metadata section to be H3 avoiding this error

## Screenshots

<details>

<summary>Before</summary>

<img width="1920" height="934" alt="Screenshot 2026-05-20 at 20 13 48" src="https://github.com/user-attachments/assets/a58bd3f1-73e6-47b3-8156-0fb7a17aac9b" />
<img width="1918" height="829" alt="Screenshot 2026-05-20 at 20 27 26" src="https://github.com/user-attachments/assets/7e9381cc-56ab-4a91-8194-d289957657f0" />


</details>

<details>

<summary>After</summary>

<img width="1902" height="804" alt="Screenshot 2026-05-20 at 20 26 24" src="https://github.com/user-attachments/assets/794b1883-4147-4e30-8af2-8bbe4474619a" />
<img width="1920" height="687" alt="Screenshot 2026-05-20 at 20 27 49" src="https://github.com/user-attachments/assets/534bdbe4-4238-4f8f-8835-85d251238fdb" />


</details>