### PR TITLE
ERM-3992: On linking an eholding resource to an agreement line the link to view resource is incorrect

### DIFF
--- a/src/components/EResourceLink/EResourceLink.js
+++ b/src/components/EResourceLink/EResourceLink.js
@@ -34,6 +34,10 @@ class EResourceLink extends React.Component {
     if (authority === 'EKB-PACKAGE') return urls.eholdingsPackageView(reference);
     if (authority === 'EKB-TITLE') return urls.eholdingsResourceView(reference);
 
+    // For specific use in form components where the eresource may not have a reference_object, but we can determine the path based on the type or authority of the eresource itself.
+    if (eresource.type === 'packages') return urls.eholdingsPackageView(eresource.id);
+    if (eresource.type === 'titles') return urls.eholdingsResourceView(eresource.id);
+
     if (type === BASKET_TYPE_GOKB_TITLE) {
       return urls.gokbResourceView(eresource.id);
     }


### PR DESCRIPTION
Due to the EResourceLink component expecting an ERM shape, but has use within the agreement lines form where eholdings objects are used, ended up linking to an incorrect location