### PR TITLE
feat: Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings" -- ERM-4008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 12.2.0 IN PROGRESS
   * ERM-4014: Change default `headingLevel` in meta section header to `3`
+  * ERM-4007 Populate `resourceName` when adding an eHoldings resource to an agreement line via "eHoldings"
 
 ## 12.1.0 2026-04-17
   * ERM-3975: Agreements|Local KB Package view: List item li does not have a ul parent element

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,6 +2,7 @@ export { default as useAcqMethods } from './useAcqMethods';
 export { default as useAgreementsContexts } from './useAgreementsContexts';
 export { default as useAgreementsDisplaySettings } from './useAgreementsDisplaySettings';
 export { default as useChunkedOrderLines } from './useChunkedOrderLines';
+export { useExternalEntitlements } from './useExternalEntitlements';
 export { default as useSuppressFromDiscovery } from './useSuppressFromDiscovery';
 export { default as useAddFromBasket } from './useAddFromBasket';
 export { default as useAgreementsRefdata } from './useAgreementsRefdata';

--- a/src/hooks/useExternalEntitlements/index.js
+++ b/src/hooks/useExternalEntitlements/index.js
@@ -1,0 +1,1 @@
+export { useExternalEntitlements } from './useExternalEntitlements';

--- a/src/hooks/useExternalEntitlements/useExternalEntitlements.js
+++ b/src/hooks/useExternalEntitlements/useExternalEntitlements.js
@@ -1,0 +1,23 @@
+import { useQuery } from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { AGREEMENT_LINES_EXTERNAL_ENDPOINT } from '../../constants';
+
+export const useExternalEntitlements = (options = {}) => {
+  const {
+    enabled = true,
+    searchParams,
+    tenantId,
+  } = options;
+
+  const ky = useOkapiKy({ tenant: tenantId });
+
+  const result = useQuery({
+    queryKey: [AGREEMENT_LINES_EXTERNAL_ENDPOINT, searchParams, tenantId],
+    queryFn: () => ky.get(AGREEMENT_LINES_EXTERNAL_ENDPOINT, { searchParams }).json(),
+    enabled,
+  });
+
+  return result;
+};

--- a/src/hooks/useExternalEntitlements/useExternalEntitlements.js
+++ b/src/hooks/useExternalEntitlements/useExternalEntitlements.js
@@ -4,20 +4,31 @@ import { useOkapiKy } from '@folio/stripes/core';
 
 import { AGREEMENT_LINES_EXTERNAL_ENDPOINT } from '../../constants';
 
-export const useExternalEntitlements = (options = {}) => {
-  const {
-    enabled = true,
-    searchParams,
-    tenantId,
-  } = options;
+const defaultQueryNamespaceGenerator = (searchParams, tenantId) => [
+  'ERM',
+  'AgreementLine',
+  'external',
+  AGREEMENT_LINES_EXTERNAL_ENDPOINT,
+  searchParams,
+  tenantId,
+];
 
+export const useExternalEntitlements = ({
+  queryNamespaceGenerator = defaultQueryNamespaceGenerator,
+  queryOptions = {},
+  searchParams,
+  tenantId,
+} = {}) => {
   const ky = useOkapiKy({ tenant: tenantId });
 
-  const result = useQuery({
-    queryKey: [AGREEMENT_LINES_EXTERNAL_ENDPOINT, searchParams, tenantId],
-    queryFn: () => ky.get(AGREEMENT_LINES_EXTERNAL_ENDPOINT, { searchParams }).json(),
-    enabled,
+  const { data, isLoading } = useQuery({
+    queryKey: queryNamespaceGenerator(searchParams, tenantId),
+    queryFn: ({ signal }) => ky.get(AGREEMENT_LINES_EXTERNAL_ENDPOINT, { searchParams, signal }).json(),
+    ...queryOptions,
   });
 
-  return result;
+  return {
+    data,
+    isLoading,
+  };
 };

--- a/src/hooks/useExternalEntitlements/useExternalEntitlements.test.js
+++ b/src/hooks/useExternalEntitlements/useExternalEntitlements.test.js
@@ -1,48 +1,87 @@
 import {
-  QueryClient,
-  QueryClientProvider,
+  useQuery,
+  mockGetQueryReturn,
 } from 'react-query';
 
-import {
-  renderHook,
-  waitFor,
-} from '@folio/jest-config-stripes/testing-library/react';
-import { useOkapiKy } from '@folio/stripes/core';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import { mockKy } from '@folio/stripes/core';
 
 import { externalEntitlements } from '../../../test/jest/entitlements';
 import { AGREEMENT_LINES_EXTERNAL_ENDPOINT } from '../../constants';
 import { useExternalEntitlements } from './useExternalEntitlements';
 
-jest.unmock('react-query');
-
-const queryClient = new QueryClient();
-const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    {children}
-  </QueryClientProvider>
-);
-
-const DATA = externalEntitlements[0];
-
-const mockGet = jest.fn().mockReturnValue({ json: () => Promise.resolve(DATA) });
+const customQueryNamespaceGenerator = jest.fn((searchParams, tenantId) => [
+  'ERM',
+  'AgreementLine',
+  'external',
+  AGREEMENT_LINES_EXTERNAL_ENDPOINT,
+  searchParams,
+  tenantId,
+]);
 
 describe('useExternalEntitlements', () => {
-  beforeEach(() => {
-    useOkapiKy.mockReturnValue({ get: mockGet });
-  });
+  describe.each([
+    {
+      testTitle: 'basic use',
+      useExternalEntitlementsProps: {
+        searchParams: { filter: 'test' },
+      },
+      expectedKyCall: AGREEMENT_LINES_EXTERNAL_ENDPOINT,
+      expectedReturn: externalEntitlements[0],
+      expectedQueryNamespace: customQueryNamespaceGenerator({ filter: 'test' }),
+    },
+    {
+      testTitle: 'custom query namespace generator',
+      useExternalEntitlementsProps: {
+        searchParams: { filter: 'custom' },
+      },
+      expectedKyCall: AGREEMENT_LINES_EXTERNAL_ENDPOINT,
+      expectedReturn: externalEntitlements[0],
+      expectedQueryNamespace: customQueryNamespaceGenerator({ filter: 'custom' }),
+    },
+  ])('$testTitle', ({
+    useExternalEntitlementsProps = {},
+    expectedKyCall,
+    expectedQueryNamespace,
+    expectedQueryOpts,
+    expectedReturn
+  }) => {
+    let result;
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+    beforeEach(() => {
+      mockGetQueryReturn.mockImplementation(() => ({ data: expectedReturn }));
 
-  it('should fetch external entitlements with provided parameters', async () => {
-    const searchParams = { authority: DATA.authority, reference: DATA.reference };
+      result = renderHook(() => useExternalEntitlements(useExternalEntitlementsProps)).result;
+    });
 
-    const { result } = renderHook(() => useExternalEntitlements({ searchParams }), { wrapper });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-    await waitFor(() => expect(result.current.isFetched).toBeTruthy());
+    it('should make a call with the expected path and search params', () => {
+      expect(mockKy).toHaveBeenCalledWith(
+        expectedKyCall,
+        expect.objectContaining({ searchParams: useExternalEntitlementsProps.searchParams }),
+      );
+    });
 
-    expect(mockGet).toHaveBeenCalledWith(AGREEMENT_LINES_EXTERNAL_ENDPOINT, { searchParams });
-    expect(result.current.data).toEqual(DATA);
+    it('should return the expected data', () => {
+      expect(result.current.data).toEqual(expectedReturn);
+    });
+
+    it('should call useQuery with the expected namespace and options', () => {
+      if (typeof useExternalEntitlementsProps.queryNamespaceGenerator === 'function') {
+        expect(customQueryNamespaceGenerator).toHaveBeenCalledWith(
+          useExternalEntitlementsProps.searchParams,
+          useExternalEntitlementsProps.tenantId,
+        );
+      }
+
+      expect(useQuery).toHaveBeenCalledWith(expect.objectContaining({
+        queryKey: expectedQueryNamespace,
+        queryFn: expect.any(Function),
+        ...expectedQueryOpts,
+      }));
+    });
   });
 });

--- a/src/hooks/useExternalEntitlements/useExternalEntitlements.test.js
+++ b/src/hooks/useExternalEntitlements/useExternalEntitlements.test.js
@@ -1,0 +1,48 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import {
+  renderHook,
+  waitFor,
+} from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { externalEntitlements } from '../../../test/jest/entitlements';
+import { AGREEMENT_LINES_EXTERNAL_ENDPOINT } from '../../constants';
+import { useExternalEntitlements } from './useExternalEntitlements';
+
+jest.unmock('react-query');
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const DATA = externalEntitlements[0];
+
+const mockGet = jest.fn().mockReturnValue({ json: () => Promise.resolve(DATA) });
+
+describe('useExternalEntitlements', () => {
+  beforeEach(() => {
+    useOkapiKy.mockReturnValue({ get: mockGet });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch external entitlements with provided parameters', async () => {
+    const searchParams = { authority: DATA.authority, reference: DATA.reference };
+
+    const { result } = renderHook(() => useExternalEntitlements({ searchParams }), { wrapper });
+
+    await waitFor(() => expect(result.current.isFetched).toBeTruthy());
+
+    expect(mockGet).toHaveBeenCalledWith(AGREEMENT_LINES_EXTERNAL_ENDPOINT, { searchParams });
+    expect(result.current.data).toEqual(DATA);
+  });
+});

--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -77,9 +77,11 @@ const AgreementCreateRoute = ({
     data: externalEntitlement,
     isLoading: isEHoldingEntitlementLoading,
   } = useExternalEntitlements({
-    searchParams: { authority, referenceId },
+    searchParams: { authority, reference: referenceId },
     queryOptions: { enabled: Boolean(authority && referenceId) },
   });
+
+  console.log('externalEntitlement', externalEntitlement);
 
   const accessControlData = useGetAccess({
     resourceEndpoint: AGREEMENTS_ENDPOINT,

--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -21,7 +21,12 @@ import NoPermissions from '../../components/NoPermissions';
 import { urls } from '../../components/utilities';
 
 import { AGREEMENTS_ENDPOINT } from '../../constants';
-import { useAddFromBasket, useAgreementsRefdata, useBasket } from '../../hooks';
+import {
+  useAddFromBasket,
+  useAgreementsRefdata,
+  useBasket,
+  useExternalEntitlements,
+} from '../../hooks';
 
 const [
   AGREEMENT_STATUS,
@@ -66,6 +71,15 @@ const AgreementCreateRoute = ({
     isExternalEntitlementLoading,
     getAgreementLinesToAdd
   } = useAddFromBasket(basket);
+
+  // if authority && referenceId exist we can assume the call came from e-holdings
+  const {
+    data: externalEntitlement,
+    isLoading: isEHoldingEntitlementLoading,
+  } = useExternalEntitlements({
+    searchParams: { authority, referenceId },
+    enabled: Boolean(authority && referenceId),
+  });
 
   const accessControlData = useGetAccess({
     resourceEndpoint: AGREEMENTS_ENDPOINT,
@@ -199,7 +213,7 @@ const AgreementCreateRoute = ({
   };
 
   const fetchIsPending = () => {
-    return isExternalEntitlementLoading;
+    return isExternalEntitlementLoading || isEHoldingEntitlementLoading;
   };
 
   const getInitialValues = () => {
@@ -220,6 +234,7 @@ const AgreementCreateRoute = ({
           'type': 'external',
           'authority': authority,
           'reference': referenceId,
+          resourceName: externalEntitlement?.reference_object?.label,
         }
       ];
     }

--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -78,7 +78,7 @@ const AgreementCreateRoute = ({
     isLoading: isEHoldingEntitlementLoading,
   } = useExternalEntitlements({
     searchParams: { authority, referenceId },
-    enabled: Boolean(authority && referenceId),
+    queryOptions: { enabled: Boolean(authority && referenceId) },
   });
 
   const accessControlData = useGetAccess({

--- a/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
+++ b/src/routes/AgreementCreateRoute/AgreementCreateRoute.js
@@ -81,8 +81,6 @@ const AgreementCreateRoute = ({
     queryOptions: { enabled: Boolean(authority && referenceId) },
   });
 
-  console.log('externalEntitlement', externalEntitlement);
-
   const accessControlData = useGetAccess({
     resourceEndpoint: AGREEMENTS_ENDPOINT,
     queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'Agreement', canDo]


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
https://folio-org.atlassian.net/browse/ERM-4007

Populate resourceName when linking an eHoldings resource to an agreement line so that it can be used for search, display

## Screen recordings


https://github.com/user-attachments/assets/e1c68937-5a7f-475a-a05d-d46de98c5c8c

https://github.com/user-attachments/assets/10c00dc4-a48e-4336-bd1e-e00894899b29

