### PR TITLE
[ERM-4070] Prevent propagation of the edit shortcut "Ctrl-Alt-E"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-agreements
 
-## 12.2.0 IN PROGRESS
+## 12.1.2 IN PROGRESS
+  * ERM-4070: Prevent propagation of the edit shortcut "Ctrl-Alt-E", as this results in typing a Euro symbol `€` into the focused field when using a German keyboard layout on Windows.
 
 ## 12.1.1 2026-05-29
   * ERM-4061: Focus pulled to "Replace agreement' agreement button in Related agreement card

--- a/src/components/views/Platform/Platform.js
+++ b/src/components/views/Platform/Platform.js
@@ -59,7 +59,10 @@ const Platform = ({
   const shortcuts = [
     {
       name: 'edit',
-      handler: handlers.onEdit,
+      handler: (e) => {
+        e.preventDefault();
+        return handlers.onEdit(e);
+      }
     },
     {
       name: 'expandAllSections',


### PR DESCRIPTION
Allowing the keystroke to propagate (the default behaviour of the HotKeys library) results in typing a Euro symbol `€` into the focused field when using a German keyboard layout on Windows.